### PR TITLE
Holy/Comet combo

### DIFF
--- a/XIVComboExpanded/Combos/PCT.cs
+++ b/XIVComboExpanded/Combos/PCT.cs
@@ -123,21 +123,18 @@ internal static class PCT
             StarPrism2 = 100;
     }
 
-    //internal class PictomancerHolyCometCombo : CustomCombo
-    //{
-    //    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerHolyCometCombo;
+    internal class PictomancerHolyCometCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerHolyCometCombo;
 
-    //    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    //    {
-    //        var gauge = GetJobGauge<PCTGauge>();
-    //        if (actionID == PCT.MiracleWhite && gauge.Black > 0)
-    //        {
-    //            {
-    //                return PCT.CometBlack;
-    //            }
-    //            return actionID;
-    //    }
-    //}
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == PCT.MiracleWhite && HasEffect(PCT.Buffs.InvertedColors))
+                return PCT.CometBlack;
+
+            return actionID;
+        }
+    }
 
     //internal class PictomancerHolyAutoCombo : CustomCombo
     //{

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -659,18 +659,18 @@ public enum CustomComboPreset
     // ====================================================================================
     #region PICTOMANCER
 
-    [CustomComboInfo("Subtractive Single-Target Combo", "Replace Fire in Red and its combo chain with Blizzard in Cyan and its combo chain when Subtractive Palette is active.", PCT.JobID)]
+    [CustomComboInfo("Subtractive Single-Target Combo", "Replace Blizzard in Cyan and its combo chain with Fire in Red and its combo chain when Subtractive Palette is not active.", PCT.JobID)]
     PictomancerSubtractiveSTCombo = 4201,
 
-    [CustomComboInfo("Subtractive AoE Combo", "Replace Fire II in Red and its combo chain with Blizzard II in Cyan and its combo chain when Subtractive Palette is active.", PCT.JobID)]
+    [CustomComboInfo("Subtractive AoE Combo", "Replace Blizzard II in Cyan and its combo chain with Fire II in Red and its combo chain when Subtractive Palette is not active.", PCT.JobID)]
     PictomancerSubtractiveAoECombo = 4202,
 
     //[SecretCustomCombo]
     //[CustomComboInfo("Subtractive Autocast", "Replace Fire in Red and Fire II in Red, and their combo chains, with Subtractive Palette if the next cast in the chain would overcap the Palette Gauge.", PCT.JobID)]
     //PictomancerSubtractiveAutoCombo = 4205,
 
-    //[CustomComboInfo("Holy Comet Combo", "Replace Holy in White with Comet in Black when usable.", PCT.JobID)]
-    //PictomancerHolyCometCombo = 4203,
+    [CustomComboInfo("Holy Comet Combo", "Replace Holy in White with Comet in Black when usable.", PCT.JobID)]
+    PictomancerHolyCometCombo = 4203,
 
     //[SecretCustomCombo]
     //[CustomComboInfo("Holy Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Holy or Comet if the next cast would overcap the Paint Gauge.", PCT.JobID)]


### PR DESCRIPTION
- Implemented PictomancerHolyCometCombo using the Monochrome Tones buff rather than the (not yet implemented) gauge.
- Corrected description of the two Pictomancer Subtractive Palette combos to reflect their actual behavior.

I'm not even sure the gauge implementation will have a Black Paint counter.  Mechanically, the Black Paint occurs just when you have White Paint _and_ also have the Monochrome Tones buff.  This implementation also has the effect of changing Holy to Comet if you have the buff but do not yet have any paint, as the next paint generated will still be counted as black paint and Comet will still be required over Holy.  This avoids the button suddenly swapping on the bar once the paint is generated.

Basically, we don't even need the gauge for this one, because the Monochrome Tones buff is the one that actually mechanically controls whether Comet or Holy is available.  You can't cast Comet without that buff, and you can't cast Holy with it.

Also corrected the descriptions of the Subtractive Palette combos, because how they're implemented, they replace Blizzard with Fire when Subtractive is inactive, rather than replacing Fire with Blizzard when Subtractive is active, as they previously stated.