### PR TITLE
[FEATURE] WAR - Primal Ruination and Primal Wrath

### DIFF
--- a/XIVComboExpanded/Combos/WAR.cs
+++ b/XIVComboExpanded/Combos/WAR.cs
@@ -30,7 +30,9 @@ internal static class WAR
         NascentFlash = 16464,
         InnerChaos = 16465,
         Bloodwhetting = 25751,
-        PrimalRend = 25753;
+        PrimalRend = 25753,
+        PrimalWrath = 36924,
+        PrimalRuination = 36925;
 
     public static class Buffs
     {
@@ -39,7 +41,9 @@ internal static class WAR
             InnerRelease = 1177,
             NascentChaos = 1897,
             PrimalRendReady = 2624,
-            SurgingTempest = 2677;
+            SurgingTempest = 2677,
+            Wrathful = 3901,
+            PrimalRuinationReady = 3834;
     }
 
     public static class Debuffs
@@ -68,7 +72,9 @@ internal static class WAR
             NascentFlash = 76,
             InnerChaos = 80,
             Bloodwhetting = 82,
-            PrimalRend = 90;
+            PrimalRend = 90,
+            PrimalWrath = 96,
+            PrimalRuination = 100;
     }
 }
 
@@ -236,6 +242,12 @@ internal class WarriorBerserkInnerRelease : CustomCombo
     {
         if (actionID == WAR.Berserk || actionID == WAR.InnerRelease)
         {
+            if (level >= WAR.Levels.PrimalWrath && HasEffect(WAR.Buffs.Wrathful))
+                return WAR.PrimalWrath;
+
+            if (level >= WAR.Levels.PrimalRuination && HasEffect(WAR.Buffs.PrimalRuinationReady))
+                return WAR.PrimalRuination;
+
             if (level >= WAR.Levels.PrimalRend && HasEffect(WAR.Buffs.PrimalRendReady))
                 return WAR.PrimalRend;
         }


### PR DESCRIPTION
- Implemented handling for Primal Ruination and Primal Wrath for WAR.
- Primal Wrath is currently prioritized over Primal Ruination if both are available, since it is an oGCD.

Fixes #257