### PR TITLE
[FEATURE] RDM - Grand Impact support

### DIFF
--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -36,7 +36,10 @@ internal static class RDM
         Scorch = 16530,
         Verthunder3 = 25855,
         Veraero3 = 25856,
-        Resolution = 25858;
+        Resolution = 25858,
+        ViceOfThorns = 37005,
+        GrandImpact = 37006,
+        Prefulgence = 37007;
 
     public static class Buffs
     {
@@ -46,7 +49,10 @@ internal static class RDM
             VerstoneReady = 1235,
             Acceleration = 1238,
             Dualcast = 1249,
-            LostChainspell = 2560;
+            LostChainspell = 2560,
+            ThornedFlourish = 3876,
+            GrandImpactReady = 3877,
+            PrefulgenceReady = 3878;
     }
 
     public static class Debuffs
@@ -78,7 +84,10 @@ internal static class RDM
             Scorch = 80,
             Veraero3 = 82,
             Verthunder3 = 82,
-            Resolution = 90;
+            Resolution = 90,
+            ViceOfThorns = 92,
+            GrandImpact = 96,
+            Prefulgence = 100;
     }
 }
 
@@ -272,8 +281,12 @@ internal class RedMageVerstoneVerfire : CustomCombo
                 }
             }
 
+
             if (IsEnabled(CustomComboPreset.RedMageVerprocPlusFeature))
             {
+                if (!IsEnabled(CustomComboPreset.RedMageGrandImpactDeprioritize) && HasEffect(RDM.Buffs.GrandImpactReady))
+                    return RDM.GrandImpact;
+
                 if (level >= RDM.Levels.Veraero && (HasEffect(RDM.Buffs.Dualcast) || HasEffect(RDM.Buffs.Acceleration) || HasEffect(RDM.Buffs.Swiftcast) || HasEffect(RDM.Buffs.LostChainspell)))
                     // Veraero3
                     return OriginalHook(RDM.Veraero);
@@ -288,6 +301,9 @@ internal class RedMageVerstoneVerfire : CustomCombo
 
             if (IsEnabled(CustomComboPreset.RedMageVerprocFeature))
             {
+                if (HasEffect(RDM.Buffs.GrandImpactReady))
+                    return RDM.GrandImpact;
+
                 if (HasEffect(RDM.Buffs.VerstoneReady))
                     return RDM.Verstone;
 
@@ -320,6 +336,9 @@ internal class RedMageVerstoneVerfire : CustomCombo
 
             if (IsEnabled(CustomComboPreset.RedMageVerprocPlusFeature))
             {
+                if (!IsEnabled(CustomComboPreset.RedMageGrandImpactDeprioritize) && HasEffect(RDM.Buffs.GrandImpactReady))
+                    return RDM.GrandImpact;
+
                 if (level >= RDM.Levels.Verthunder && (HasEffect(RDM.Buffs.Dualcast) || HasEffect(RDM.Buffs.Acceleration) || HasEffect(RDM.Buffs.Swiftcast) || HasEffect(RDM.Buffs.LostChainspell)))
                     // Verthunder3
                     return OriginalHook(RDM.Verthunder);
@@ -334,6 +353,9 @@ internal class RedMageVerstoneVerfire : CustomCombo
 
             if (IsEnabled(CustomComboPreset.RedMageVerprocFeature))
             {
+                if (HasEffect(RDM.Buffs.GrandImpactReady))
+                    return RDM.GrandImpact;
+
                 if (HasEffect(RDM.Buffs.VerfireReady))
                     return RDM.Verfire;
 
@@ -356,6 +378,9 @@ internal class RedMageAcceleration : CustomCombo
         {
             if (level >= RDM.Levels.Acceleration)
             {
+                if (IsEnabled(CustomComboPreset.RedMageAccelerationGrandImpactFeature) && HasEffect(RDM.Buffs.GrandImpactReady))
+                    return RDM.GrandImpact;
+
                 if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption))
                 {
                     if (IsOffCooldown(RDM.Acceleration) && IsOffCooldown(ADV.Swiftcast))

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -828,11 +828,15 @@ public enum CustomComboPreset
     // ====================================================================================
     #region RED MAGE
 
-    [CustomComboInfo("Verstone/Verfire Feature", "Replace Verstone/Verfire with Jolt/Scorch when no proc is available.", RDM.JobID)]
+    [CustomComboInfo("Verstone/Verfire Feature", "Replace Verstone/Verfire with Jolt when no proc is available.", RDM.JobID)]
     RedMageVerprocFeature = 3504,
 
     [CustomComboInfo("Verstone/Verfire Plus Feature", "Replace Verstone/Verfire with Veraero/Verthunder when various instant-cast effects are active.", RDM.JobID)]
     RedMageVerprocPlusFeature = 3505,
+
+    [ParentCombo(RedMageVerprocPlusFeature)]
+    [CustomComboInfo("Deprioritize Grand Impact", "After using Acceleration, prioritize using Veraero/Verthunder over Grand Impact if both buffs are active.", RDM.JobID)]
+    RedMageGrandImpactDeprioritize = 3517,
 
     [CustomComboInfo("Verstone/Verfire Plus Opener Feature (Stone)", "Replace Verstone with Veraero when out of combat.", RDM.JobID)]
     RedMageVerprocOpenerStoneFeature = 3506,
@@ -863,6 +867,9 @@ public enum CustomComboPreset
 
     [CustomComboInfo("Melee Capstone Combo", "Replace Redoublement and Moulinet with Scorch and Resolution when available.", RDM.JobID)]
     RedMageMeleeCapstoneCombo = 3503,
+
+    [CustomComboInfo("Acceleration into Grand Impact", "Replace Acceleration with Grand Impact when available.", RDM.JobID)]
+    RedMageAccelerationGrandImpactFeature = 3518,
 
     [CustomComboInfo("Acceleration into Swiftcast", "Replace Acceleration with Swiftcast when on cooldown or synced.", RDM.JobID)]
     RedMageAccelerationSwiftcastFeature = 3509,


### PR DESCRIPTION
- Added support for Grand Impact.
- By default, Grand Impact will be prioritized over Veraero/Verthunder, and will always be prioritized over Verstone/Verfire.
- Added a combo to prioritize Veraero/Verthunder over Grand Impact, if the user wishes.
- Added a combo to add Grand Impact to Acceleration when available.
- Fixed the inaccurate reference to Scorch in the RedMageVerprocFeature description.
- Also added the spell ID, level, and relevant buff for the other two DT abilities, Prefulgence and Vice of Thorns.  No combos implemented for either yet, though.

Fixed #259 