### PR TITLE
[FEATURE] SAM - Zanshin Support

### DIFF
--- a/XIVComboExpanded/Combos/SAM.cs
+++ b/XIVComboExpanded/Combos/SAM.cs
@@ -34,7 +34,8 @@ internal static class SAM
         Ikishoten = 16482,
         //Shoha2 = 25779,
         OgiNamikiri = 25781,
-        KaeshiNamikiri = 25782;
+        KaeshiNamikiri = 25782,
+        Zanshin = 36964;
 
     public static class Buffs
     {
@@ -295,6 +296,12 @@ internal class SamuraiShinten : CustomCombo
                     if (level >= SAM.Levels.HissatsuGuren && level < SAM.Levels.HissatsuSenei && IsOffCooldown(SAM.HissatsuGuren))
                         return SAM.HissatsuGuren;
                 }
+            }
+
+            if (IsEnabled(CustomComboPreset.SamuraiShintenZanshinFeature))
+            {
+                if (level >= SAM.Levels.Zanshin && HasEffect(SAM.Buffs.ZanshinReady))
+                    return SAM.Zanshin;
             }
         }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -965,17 +965,17 @@ public enum CustomComboPreset
     [CustomComboInfo("Iaijutsu to Shoha", "Replace Iaijutsu with Shoha when meditation is 3.", SAM.JobID)]
     SamuraiIaijutsuShohaFeature = 3410,
 
-    [CustomComboInfo("Senei to Guren Level Sync", "Replace Hissatsu: Senei with Guren when level synced below 72.", SAM.JobID)]
-    SamuraiSeneiGurenFeature = 3418,
+    [CustomComboInfo("Shinten to Zanshin", "Replace Hissatsu: Shinten with Zanshin when available.", SAM.JobID)]
+    SamuraiShintenZanshinFeature = 3420,
+
+    [CustomComboInfo("Shinten to Shoha", "Replace Hissatsu: Shinten with Shoha when Meditation is full.", SAM.JobID)]
+    SamuraiShintenShohaFeature = 3413,
 
     [CustomComboInfo("Shinten to Senei", "Replace Hissatsu: Shinten with Senei when available.", SAM.JobID)]
     SamuraiShintenSeneiFeature = 3414,
 
-    [CustomComboInfo("Shinten to Zanshin", "Replace Hissatsu: Shinten with Zanshin when available.", SAM.JobID)]
-    SamuraiShintenZanshinFeature = 3420,
-    
-    [CustomComboInfo("Shinten to Shoha", "Replace Hissatsu: Shinten with Shoha when Meditation is full.", SAM.JobID)]
-    SamuraiShintenShohaFeature = 3413,
+    [CustomComboInfo("Senei to Guren Level Sync", "Replace Hissatsu: Senei with Guren when level synced below 72.", SAM.JobID)]
+    SamuraiSeneiGurenFeature = 3418,
 
     [CustomComboInfo("Kyuten to Guren", "Replace Hissatsu: Kyuten with Guren when available.", SAM.JobID)]
     SamuraiKyutenGurenFeature = 3415,

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -971,6 +971,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Shinten to Senei", "Replace Hissatsu: Shinten with Senei when available.", SAM.JobID)]
     SamuraiShintenSeneiFeature = 3414,
 
+    [CustomComboInfo("Shinten to Zanshin", "Replace Hissatsu: Shinten with Zanshin when available.", SAM.JobID)]
+    SamuraiShintenZanshinFeature = 3420,
+    
     [CustomComboInfo("Shinten to Shoha", "Replace Hissatsu: Shinten with Shoha when Meditation is full.", SAM.JobID)]
     SamuraiShintenShohaFeature = 3413,
 


### PR DESCRIPTION
Replace Shinten with Zanshin while under the effect of Zanshin Ready.

Confirmed the action ID for Zanshin using ReAction.

![image](https://github.com/MKhayle/XIVComboExpanded/assets/7474327/4d4469a1-c610-4895-8961-ca4db16276c6)