### PR TITLE
RPR: bugfix for gluttony's executioner gibblet/gallows/guillotine.

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -50,6 +50,7 @@ internal static class RPR
         public const ushort
             EnhancedHarpe = 2845,
             SoulReaver = 2587,
+            Executioner = 3858,
             EnhancedGibbet = 2588,
             EnhancedGallows = 2589,
             EnhancedVoidReaping = 2590,
@@ -88,7 +89,8 @@ internal static class RPR
             EnhancedShroud = 86,
             LemuresScythe = 86,
             PlentifulHarvest = 88,
-            Communio = 90;
+            Communio = 90,
+            Executioner = 96;            
     }
 }
 
@@ -124,6 +126,7 @@ internal class ReaperSlice : CustomCombo
             }
 
             if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
+                (level >= RPR.Levels.Executioner && HasEffect(RPR.Buffs.Executioner)) ||
                 (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
             {
                 if (IsEnabled(CustomComboPreset.ReaperSliceEnhancedEnshroudedFeature))
@@ -202,6 +205,7 @@ internal class ReaperScythe : CustomCombo
             if (IsEnabled(CustomComboPreset.ReaperScytheGuillotineFeature))
             {
                 if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
+                    (level >= RPR.Levels.Executioner && HasEffect(RPR.Buffs.Executioner)) ||
                     (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
                     // Grim Reaping
                     return OriginalHook(RPR.Guillotine);
@@ -267,6 +271,7 @@ internal class ReaperShadowOfDeath : CustomCombo
             }
 
             if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
+                (level >= RPR.Levels.Executioner && HasEffect(RPR.Buffs.Executioner)) ||
                 (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
             {
                 if (IsEnabled(CustomComboPreset.ReaperShadowGallowsFeature))
@@ -309,6 +314,7 @@ internal class ReaperSoulSlice : CustomCombo
             }
 
             if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
+                (level >= RPR.Levels.Executioner && HasEffect(RPR.Buffs.Executioner)) ||
                 (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
             {
                 if (IsEnabled(CustomComboPreset.ReaperSoulGallowsFeature))
@@ -418,6 +424,7 @@ internal class ReaperGibbetGallowsGuillotine : CustomCombo
             var gauge = GetJobGauge<RPRGauge>();
 
             if ((level >= RPR.Levels.SoulReaver && HasEffect(RPR.Buffs.SoulReaver)) ||
+                (level >= RPR.Levels.Executioner && HasEffect(RPR.Buffs.Executioner)) ||
                 (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
             {
                 if (IsEnabled(CustomComboPreset.ReaperLemuresSoulReaverFeature))


### PR DESCRIPTION
This does not change functionality of any current combos, just allows them to work after level 96. 