### PR TITLE
New feature: Replace Cast with Rest when fishing

### DIFF
--- a/XIVComboExpanded/Combos/DOL.cs
+++ b/XIVComboExpanded/Combos/DOL.cs
@@ -22,7 +22,8 @@ internal static class DOL
         MinWiseToTheWorld = 26521,
         BtnWiseToTheWorld = 26522,
         ElectricCurrent = 26872,
-        PrizeCatch = 26806;
+        PrizeCatch = 26806,
+        Rest = 37047;
 
     public static class Buffs
     {
@@ -86,6 +87,12 @@ internal class FisherCast : CustomCombo
             {
                 if (HasCondition(ConditionFlag.Fishing))
                     return DOL.Hook;
+            }
+
+            if (IsEnabled(CustomComboPreset.DolCastRestFeature))
+            {
+                if (HasCondition(ConditionFlag.Fishing))
+                    return DOL.Rest;
             }
 
             if (IsEnabled(CustomComboPreset.DolCastGigFeature))

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1185,8 +1185,13 @@ public enum CustomComboPreset
     [CustomComboInfo("Eureka Feature", "Replace Ageless Words and Solid Reason with Wise to the World when available.", DOL.JobID)]
     DolEurekaFeature = 51001,
 
+    [ConflictingCombos(DolCastRestFeature)]
     [CustomComboInfo("Cast / Hook Feature", "Replace Cast with Hook when fishing.", DOL.JobID)]
     DolCastHookFeature = 51002,
+
+    [ConflictingCombos(DolCastHookFeature)]
+    [CustomComboInfo("Cast / Rest Feature", "Replace Cast with Rest when fishing.", DOL.JobID)]
+    DolCastRestFeature = 51008,
 
     [CustomComboInfo("Cast / Gig Feature", "Replace Cast with Gig when underwater.", DOL.JobID)]
     DolCastGigFeature = 51003,


### PR DESCRIPTION
This is my first foray into Dalamud plugin dev, but this change was straightforward enough! **Rest** is an invaluable new FSH skill that lets you quit a cast without quitting fishing altogether. **Cast** is definitely the best replacement target, despite the existing Hook replace feature.

Tested in-game, works like a charm.