### PR TITLE
Fix MCH Excavator

### DIFF
--- a/XIVComboExpanded/Combos/MCH.cs
+++ b/XIVComboExpanded/Combos/MCH.cs
@@ -249,8 +249,12 @@ internal class MachinistDrillAirAnchorChainsaw : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == MCH.HotShot || actionID == MCH.AirAnchor || actionID == MCH.Drill || actionID == MCH.Chainsaw)
+        if (actionID == MCH.HotShot || actionID == MCH.AirAnchor || actionID == MCH.Drill || actionID == MCH.Chainsaw || actionID == MCH.Excavator)
         {
+
+            if (level >= MCH.Levels.Excavator && HasEffect(MCH.Buffs.ExcavatorReady))
+                return MCH.Excavator;
+
             if (level >= MCH.Levels.Chainsaw)
                 return CalcBestAction(actionID, MCH.Chainsaw, MCH.AirAnchor, MCH.Drill);
 


### PR DESCRIPTION
Fix Excavator not showing in Hot Shot (Air Anchor) / Drill / Chainsaw Feature.