### PR TITLE
[FEATURE] Reaper Lemure's Slice -> Sacrificium

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -36,6 +36,8 @@ internal static class RPR
         Communio = 24398,
         LemuresSlice = 24399,
         LemuresScythe = 24400,
+        Sacrificium = 36969,
+        Perfectio = 36973,
         // Misc
         ShadowOfDeath = 24378,
         Harpe = 24386,
@@ -58,7 +60,10 @@ internal static class RPR
             ImmortalSacrifice = 2592,
             Enshrouded = 2593,
             Soulsow = 2594,
-            Threshold = 2595;
+            Threshold = 2595,
+            Oblatio = 3857,          // Sacrificium ready to use
+            PerfectioOcculta = 3859, // Turns into Perfectio Parata when Communio is used
+            PerfectioParata = 3860;  // Perfectio ready to use
     }
 
     public static class Debuffs
@@ -90,7 +95,9 @@ internal static class RPR
             LemuresScythe = 86,
             PlentifulHarvest = 88,
             Communio = 90,
-            Executioner = 96;            
+            Sacrificium = 92,
+            Executioner = 96,
+            Perfectio = 100;
     }
 }
 
@@ -383,8 +390,14 @@ internal class ReaperBloodStalk : CustomCombo
 
             if (IsEnabled(CustomComboPreset.ReaperBloodStalkGluttonyFeature))
             {
-                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsOffCooldown(RPR.Gluttony))
+                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsOffCooldown(RPR.Gluttony) && gauge.EnshroudedTimeRemaining == 0)
                     return RPR.Gluttony;
+            }
+
+            if (IsEnabled(CustomComboPreset.ReaperLemuresSacrificiumFeature))
+            {
+                if (level >= RPR.Levels.Sacrificium && HasEffect(RPR.Buffs.Oblatio) && gauge.EnshroudedTimeRemaining > 0 && (gauge.VoidShroud < 2 || IsEnabled(CustomComboPreset.ReaperLemuresSacrificiumPriorityFeature)))
+                    return RPR.Sacrificium;
             }
         }
 
@@ -404,8 +417,14 @@ internal class ReaperGrimSwathe : CustomCombo
 
             if (IsEnabled(CustomComboPreset.ReaperGrimSwatheGluttonyFeature))
             {
-                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsOffCooldown(RPR.Gluttony))
+                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsOffCooldown(RPR.Gluttony) && gauge.EnshroudedTimeRemaining == 0)
                     return RPR.Gluttony;
+            }
+
+            if (IsEnabled(CustomComboPreset.ReaperLemuresSacrificiumFeature))
+            {
+                if (level >= RPR.Levels.Sacrificium && HasEffect(RPR.Buffs.Oblatio) && gauge.EnshroudedTimeRemaining > 0 && (gauge.VoidShroud < 2 || IsEnabled(CustomComboPreset.ReaperLemuresSacrificiumPriorityFeature)))
+                    return RPR.Sacrificium;
             }
         }
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -800,6 +800,13 @@ public enum CustomComboPreset
     [CustomComboInfo("Grim Swathe Gluttony Feature", "Replace Grim Swathe with Gluttony when available and greater-than-or-equal-to 50 Soul Gauge is present.", RPR.JobID)]
     ReaperGrimSwatheGluttonyFeature = 3916,
 
+    [CustomComboInfo("Lemure's Sacrificium Feature", "Replace Lemure's Slice/Scythe with Sacrificium when available and you have fewer than 2 Void Shroud.", RPR.JobID)]
+    ReaperLemuresSacrificiumFeature = 3940,
+
+    [ParentCombo(ReaperLemuresSacrificiumFeature)]
+    [CustomComboInfo("Prioritize Sacrificium over Lemure's", "Replace Lemure's Slice/Scythe with Sacrificium even when you have 2 Void Shroud.", RPR.JobID)]
+    ReaperLemuresSacrificiumPriorityFeature = 3941,
+
     [CustomComboInfo("Arcane Harvest Feature", "Replace Arcane Circle with Plentiful Harvest when you have stacks of Immortal Sacrifice.", RPR.JobID)]
     ReaperHarvestFeature = 3908,
 


### PR DESCRIPTION
- Implemented combo that turns Lemure's Slice/Scythe into Sacrificium when less than 2 Void Shroud (ie Lemure's Slice and Scythe not usable).
- Implemented sub-combo to override this priority and always replace Lemure's Slice/Scythe with Sacrificium when it is available.

Tested and working locally.

Edit: Fixes #277, related to #276