### PR TITLE
[BUGFIX] Gemshine + Enkindle and Requiescat + Goring

### DIFF
--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -305,10 +305,9 @@ internal class PaladinRequiescat : PaladinCombo
                 // single GCD.
                 if (IsEnabled(CustomComboPreset.PaladinRequiescatFightOrFlightFeature) && IsEnabled(CustomComboPreset.PaladinFightOrFlightGoringBladeFeature))
                 {
-                    if (level >= PLD.Levels.GoringBlade && IsOffCooldown(PLD.GoringBlade))
+                    if (HasEffect(PLD.Buffs.GoringBladeReady))
                     {
-                        if (HasEffect(PLD.Buffs.GoringBladeReady))
-                            return PLD.GoringBlade;
+                        return PLD.GoringBlade;
                     }
                 }
 

--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -305,7 +305,10 @@ internal class PaladinRequiescat : PaladinCombo
                 // single GCD.
                 if (IsEnabled(CustomComboPreset.PaladinRequiescatFightOrFlightFeature) && IsEnabled(CustomComboPreset.PaladinFightOrFlightGoringBladeFeature))
                 {
-                    if (HasEffect(PLD.Buffs.GoringBladeReady))
+                    // Don't use Goring Blade until Requiescat is on cooldown, unless it somehow got desynced and is >5s left on its cooldown.
+                    // This prevents an odd effect where shortly after casting Fight or Flight, Goring Blade would be cast instead of Requiescat, causing drift.
+                    var req = GetCooldown(PLD.Requiescat);
+                    if (HasEffect(PLD.Buffs.GoringBladeReady) && req.CooldownElapsed > 0 && req.CooldownElapsed < 55)
                     {
                         return PLD.GoringBlade;
                     }

--- a/XIVComboExpanded/Combos/SMN.cs
+++ b/XIVComboExpanded/Combos/SMN.cs
@@ -227,7 +227,7 @@ internal class SummonerGemshinePreciousBrilliance : CustomCombo
 
             if (IsEnabled(CustomComboPreset.SummonerShinyEnkindleFeature))
             {
-                if (level >= SMN.Levels.EnkindleBahamut && !gauge.IsIfritAttuned && !gauge.IsTitanAttuned && !gauge.IsGarudaAttuned && gauge.SummonTimerRemaining > 0)
+                if (level >= SMN.Levels.EnkindleBahamut && gauge.SummonTimerRemaining > 0 && gauge.AttunmentTimerRemaining == 0)
                     // Rekindle
                     return OriginalHook(SMN.EnkindleBahamut);
             }


### PR DESCRIPTION
- [PLD] Fixed the FoF Goring Blade combo when used with Requiescat FoF combo.
- [SMN] Fixed the Gems Enkindle Feature.
  - I'm not sure what changed about the gauge, but the `IsXAttuned` fields aren't working as they used to.  Swapped to `AttunmentTimerRemaining`.
- Fixes #285

Both are working with a local build.