### PR TITLE
[FEATURE] Paladin update/refactor

### DIFF
--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -676,6 +676,14 @@ public enum CustomComboPreset
     [CustomComboInfo("Royal Authority Atonement Feature", "Replace Royal Authority with Atonement, Supplication & Sepulchre when under the effect of the corresponding buffs.", PLD.JobID)]
     PaladinRoyalAuthorityAtonementComboFeature = 1903,
 
+    [ParentCombo(PaladinRoyalAuthorityCombo)]
+    [CustomComboInfo("Royal Authority Confiteor Feature", "Replace Royal Authority with Confiteor and its combo chain when under the effect of Requiescat.", PLD.JobID)]
+    PaladinRoyalAuthorityConfiteorComboFeature = 1917,
+
+    [ParentCombo(PaladinRoyalAuthorityCombo)]
+    [CustomComboInfo("Royal Authority Goring Blade Feature", "Replace Royal Authority with Goring Blade when available.", PLD.JobID)]
+    PaladinRoyalAuthorityGoringBladeComboFeature = 1918,
+
     [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain.", PLD.JobID)]
     PaladinProminenceCombo = 1904,
 
@@ -683,14 +691,19 @@ public enum CustomComboPreset
     [CustomComboInfo("Prominence Divine Might Feature", "Replace Prominence with Holy Circle when Divine Might is active.", PLD.JobID)]
     PaladinProminenceDivineMightFeature = 1913,
 
+    [ParentCombo(PaladinProminenceCombo)]
+    [CustomComboInfo("Prominence Confiteor Feature", "Replace Prominence with Confiteor and its combo chain when under the effect of Requiescat.", PLD.JobID)]
+    PaladinProminenceConfiteorComboFeature = 1919,
+
+    [ParentCombo(PaladinProminenceCombo)]
+    [CustomComboInfo("Prominence Goring Blade Feature", "Replace Prominence with Goring Blade when available.", PLD.JobID)]
+    PaladinProminenceGoringBladeComboFeature = 1920,
+
     [CustomComboInfo("Requiescat Fight or Flight Feature", "Replace Requiescat with Fight or Flight when off cooldown or if it will be ready sooner.", PLD.JobID)]
     PaladinRequiescatFightOrFlightFeature = 1914,
 
     [CustomComboInfo("Requiescat Confiteor", "Replace Requiescat with Confiteor and combo chain while under the effect of Requiescat, and then with Holy Spirit if there are remaining charges.", PLD.JobID)]
     PaladinRequiescatCombo = 1905,
-
-    [CustomComboInfo("Fight or Flight Goring Blade Feature", "Replace Fight or Flight with Goring Blade while Fight or Flight is active.  Also applies to Requiescat if the Requiescat Fight or Flight Feature is enabled.", PLD.JobID)]
-    PaladinFightOrFlightGoringBladeFeature = 1911,
 
     [CustomComboInfo("Confiteor Feature", "Replace Holy Spirit/Circle with Confiteor while under the effect of Requiescat.", PLD.JobID)]
     PaladinConfiteorFeature = 1907,


### PR DESCRIPTION
- Removed the FoF Goring Blade feature, as it is now baseline.
- The prior check on Requiescat for including Goring Blade now depends on (and respects) the player's selection for whether FoF changes into Goring Blade in the base game.
- Implemented new features for including Goring Blade, when available, on Royal Authority and Prominence buttons.
- Implemented new features for including the Confiteor combo, when available, on Royal Authority and Prominence.
- Atonement usage outside of FoF is now delayed until it would be overwritten by Royal Authority, per current guidance in The Balance.
  - It will also be used if it would otherwise expire
- During FoF, Atonement or Holy Spirit are now intelligently prioritized based on whether the higher-potency Sepulchre can be fit inside the remaining duration.
- During both FoF and regular usage, Holy Spirit will automatically be inserted if the player is not in melee range of the target, provided Divine Might is active.
- If the player has remaining Requiescat charges (ie. under level 90, when the Blades combo followup to Confiteor is learned), Holy Spirit will be used to burn off the charges.
- Corrected MP values for spells, due to Divine Magic Mastery, added in Endwalker, halving all of the prior mana costs.
  - Technically, this returns incorrect values under level 64, but since the only mana-consuming spell learned before 64 is Clemency, and it is never used in a combo, this is irrelevant.
- Simplified some of the combo checks.  Since lastComboMove is only non-null when comboTime > 0, we can skip checking comboTime if we're already checking lastComboMove.

Fixes #298 