### PR TITLE
BLM: bugfix flare star ID and added child feature to despair

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -32,7 +32,7 @@ internal static class BLM
         HighFire2 = 25794,
         HighBlizzard2 = 25795,
         Paradox = 25797,
-        FlareStar = 38072;
+        FlareStar = 36989;
 
     public static class Buffs
     {
@@ -119,6 +119,9 @@ internal class BlackFireBlizzard4 : CustomCombo
                 {
                     if (IsEnabled(CustomComboPreset.BlackEnochianDespairFeature))
                     {
+                        if (IsEnabled(CustomComboPreset.BlackEnochianDespairFlareStarFeature))
+                            if (level >= BLM.Levels.FlareStar && gauge.AstralSoulStacks >= 6 && LocalPlayer?.CurrentMp <= 0)
+                                return BLM.FlareStar;
                         if (level >= BLM.Levels.Despair && LocalPlayer?.CurrentMp < 2400)
                             return BLM.Despair;
                     }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -161,6 +161,11 @@ public enum CustomComboPreset
     [CustomComboInfo("Enochian Despair Feature", "Replace Fire 4 and Blizzard 4 with Despair when in Astral Fire with less than 2400 mana.", BLM.JobID)]
     BlackEnochianDespairFeature = 2510,
 
+    [SecretCustomCombo]
+    [ParentCombo(BlackEnochianDespairFeature)]
+    [CustomComboInfo("Enochian Despair into Flare Star Feature", "Replace Fire 4 and Blizzard 4 with Flare Star when you have 6 astral soul and 0 mana.", BLM.JobID)]
+    BlackEnochianDespairFlareStarFeature = 2524,
+
     [ParentCombo(BlackEnochianFeature)]
     [CustomComboInfo("Enochian No Sync Feature", "Fire 4 and Blizzard 4 will not sync to Fire 1 and Blizzard 1.", BLM.JobID)]
     BlackEnochianNoSyncFeature = 2518,


### PR DESCRIPTION
Fixed wrong flare star ID (I think previous one was a Bozja action LOL)
![image](https://github.com/MKhayle/XIVComboExpanded/assets/55109682/4969395e-3324-4b04-8323-c5d4a0fd51f1)

Added despair -> flare star feature.