### PR TITLE
[BUGFIX] CalcBestAction and CooldownData

### DIFF
--- a/XIVComboExpanded/Combos/ADV.cs
+++ b/XIVComboExpanded/Combos/ADV.cs
@@ -44,7 +44,7 @@ internal class SwiftRaiseFeature : CustomCombo
             (actionID == SGE.Egeiro && level >= SGE.Levels.Egeiro) ||
             (actionID == WHM.Raise && level >= WHM.Levels.Raise))
         {
-            if (level >= ADV.Levels.Swiftcast && IsOffCooldown(ADV.Swiftcast))
+            if (level >= ADV.Levels.Swiftcast && IsCooldownUsable(ADV.Swiftcast))
                 return ADV.Swiftcast;
         }
 
@@ -57,7 +57,7 @@ internal class SwiftRaiseFeature : CustomCombo
             }
             else if (!IsEnabled(CustomComboPreset.AdvDisableVerRaiseFeature))
             {
-                if (level >= ADV.Levels.Swiftcast && IsOffCooldown(ADV.Swiftcast))
+                if (level >= ADV.Levels.Swiftcast && IsCooldownUsable(ADV.Swiftcast))
                     return ADV.Swiftcast;
             }
         }
@@ -116,7 +116,7 @@ internal class StanceProvokeFeature : CustomCombo
                     return GNB.RoyalGuard;
             }
 
-            if (IsEnabled(CustomComboPreset.AdvStanceBackProvokeFeature) && IsOnCooldown(ADV.Provoke))
+            if (IsEnabled(CustomComboPreset.AdvStanceBackProvokeFeature) && !IsCooldownUsable(ADV.Provoke))
             {
                 if (job == PLD.JobID && level >= PLD.Levels.IronWill)
                     return PLD.IronWillRemoval;
@@ -139,7 +139,7 @@ internal class ShirkStanceFeature : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == ADV.Shirk && IsOnCooldown(ADV.Shirk))
+        if (actionID == ADV.Shirk && !IsCooldownUsable(ADV.Shirk))
         {
             var job = LocalPlayer?.ClassJob.Id;
 

--- a/XIVComboExpanded/Combos/AST.cs
+++ b/XIVComboExpanded/Combos/AST.cs
@@ -89,14 +89,14 @@ internal class AstrologianMalefic : CustomCombo
             if (IsEnabled(CustomComboPreset.AstrologianMaleficArcanaFeature) && gauge.DrawnCrownCard == CardType.LORD && level >= AST.Levels.MinorArcana)
                 return OriginalHook(AST.MinorArcanaDT);
 
-            if (IsEnabled(CustomComboPreset.AstrologianDraw1Feature) && IsOriginal(AST.Play1) && (IsOffCooldown(AST.AstralDraw) || IsOffCooldown(AST.UmbralDraw)))
+            if (IsEnabled(CustomComboPreset.AstrologianDraw1Feature) && IsOriginal(AST.Play1) && (IsCooldownUsable(AST.AstralDraw) || IsCooldownUsable(AST.UmbralDraw)))
                 return gauge.ActiveDraw == DrawType.ASTRAL ? OriginalHook(AST.AstralDraw) : OriginalHook(AST.UmbralDraw);
 
             if (IsOriginal(AST.Play1)
                 && IsOriginal(AST.Play2)
                 && IsOriginal(AST.Play3)
                 && (IsOriginal(AST.MinorArcanaDT) || level < AST.Levels.MinorArcana)
-                && (IsOffCooldown(AST.AstralDraw) || IsOffCooldown(AST.UmbralDraw)))
+                && (IsCooldownUsable(AST.AstralDraw) || IsCooldownUsable(AST.UmbralDraw)))
                 return gauge.ActiveDraw == DrawType.ASTRAL ? OriginalHook(AST.AstralDraw) : OriginalHook(AST.UmbralDraw);
         }
 
@@ -121,7 +121,7 @@ internal class AstrologianGravity : CustomCombo
                 && IsOriginal(AST.Play2)
                 && IsOriginal(AST.Play3)
                 && (IsOriginal(AST.MinorArcanaDT) || level < AST.Levels.MinorArcana)
-                && (IsOffCooldown(AST.AstralDraw) || IsOffCooldown(AST.UmbralDraw)))
+                && (IsCooldownUsable(AST.AstralDraw) || IsCooldownUsable(AST.UmbralDraw)))
                 return gauge.ActiveDraw == DrawType.ASTRAL ? OriginalHook(AST.AstralDraw) : OriginalHook(AST.UmbralDraw);
         }
 

--- a/XIVComboExpanded/Combos/BRD.cs
+++ b/XIVComboExpanded/Combos/BRD.cs
@@ -216,7 +216,7 @@ internal class BardQuickNock : CustomCombo
                 {
                     if (IsEnabled(CustomComboPreset.BardShadowbiteBarrageFeature))
                     {
-                        if (level >= BRD.Levels.Barrage && IsOffCooldown(BRD.Barrage))
+                        if (level >= BRD.Levels.Barrage && IsCooldownUsable(BRD.Barrage))
                             return BRD.Barrage;
                     }
 
@@ -384,13 +384,13 @@ internal class BardRadiantFinale : CustomCombo
         {
             if (IsEnabled(CustomComboPreset.BardRadiantStrikesFeature))
             {
-                if (level >= BRD.Levels.RagingStrikes && IsOffCooldown(BRD.RagingStrikes))
+                if (level >= BRD.Levels.RagingStrikes && IsCooldownUsable(BRD.RagingStrikes))
                     return BRD.RagingStrikes;
             }
 
             if (IsEnabled(CustomComboPreset.BardRadiantVoiceFeature))
             {
-                if (level >= BRD.Levels.BattleVoice && IsOffCooldown(BRD.BattleVoice))
+                if (level >= BRD.Levels.BattleVoice && IsCooldownUsable(BRD.BattleVoice))
                     return BRD.BattleVoice;
             }
 
@@ -447,7 +447,7 @@ internal class BardMagesBallad : CustomCombo
                 if (gauge.Song == Song.WANDERER && gauge.SongTimer >= remaining)
                     return BRD.WanderersMinuet;
 
-                if (IsOffCooldown(BRD.WanderersMinuet))
+                if (IsCooldownUsable(BRD.WanderersMinuet))
                     return BRD.WanderersMinuet;
             }
 
@@ -456,7 +456,7 @@ internal class BardMagesBallad : CustomCombo
                 if (gauge.Song == Song.MAGE && gauge.SongTimer >= remaining)
                     return BRD.MagesBallad;
 
-                if (IsOffCooldown(BRD.MagesBallad))
+                if (IsCooldownUsable(BRD.MagesBallad))
                     return BRD.MagesBallad;
             }
 
@@ -465,7 +465,7 @@ internal class BardMagesBallad : CustomCombo
                 if (gauge.Song == Song.ARMY && gauge.SongTimer >= remaining)
                     return BRD.ArmysPaeon;
 
-                if (IsOffCooldown(BRD.ArmysPaeon))
+                if (IsCooldownUsable(BRD.ArmysPaeon))
                     return BRD.ArmysPaeon;
             }
 

--- a/XIVComboExpanded/Combos/DRG.cs
+++ b/XIVComboExpanded/Combos/DRG.cs
@@ -215,14 +215,14 @@ internal class DragoonStardiver : CustomCombo
 
             if (IsEnabled(CustomComboPreset.DragoonStardiverNastrondFeature))
             {
-                if (level >= DRG.Levels.Geirskogul && (!gauge.IsLOTDActive || IsOffCooldown(DRG.Nastrond) || IsOnCooldown(DRG.Stardiver)))
+                if (level >= DRG.Levels.Geirskogul && (!gauge.IsLOTDActive || IsCooldownUsable(DRG.Nastrond) || !IsCooldownUsable(DRG.Stardiver)))
                     // Nastrond
                     return OriginalHook(DRG.Geirskogul);
             }
 
             if (IsEnabled(CustomComboPreset.DragoonStardiverDragonfireDiveFeature))
             {
-                if (level < DRG.Levels.Stardiver || !gauge.IsLOTDActive || IsOnCooldown(DRG.Stardiver) || (IsOffCooldown(DRG.DragonfireDive) && gauge.LOTDTimer > 7.5))
+                if (level < DRG.Levels.Stardiver || !gauge.IsLOTDActive || !IsCooldownUsable(DRG.Stardiver) || (IsCooldownUsable(DRG.DragonfireDive) && gauge.LOTDTimer > 7.5))
                     return DRG.DragonfireDive;
             }
         }
@@ -249,7 +249,7 @@ internal class DragoonGierskogul : CustomCombo
                         ? DRG.Nastrond
                         : DRG.Geirskogul;
 
-                    if (IsOnCooldown(action))
+                    if (!IsCooldownUsable(action))
                         return DRG.WyrmwindThrust;
                 }
             }
@@ -267,10 +267,10 @@ internal class DragoonLanceCharge : CustomCombo
     {
         if (actionID == DRG.LanceCharge)
         {
-            if (!IsOnCooldown(DRG.LanceCharge))
+            if (!!IsCooldownUsable(DRG.LanceCharge))
                 return DRG.LanceCharge;
 
-            if (level >= DRG.Levels.BattleLitany && !IsOnCooldown(DRG.BattleLitany))
+            if (level >= DRG.Levels.BattleLitany && !!IsCooldownUsable(DRG.BattleLitany))
                 return DRG.BattleLitany;
         }
 

--- a/XIVComboExpanded/Combos/DRK.cs
+++ b/XIVComboExpanded/Combos/DRK.cs
@@ -192,7 +192,7 @@ internal class DarkCarveAndSpitAbyssalDrain : CustomCombo
                 if (actionID == DRK.CarveAndSpit && level < DRK.Levels.CarveAndSpit)
                     return OriginalHook(DRK.BloodWeapon);
 
-                if (level >= DRK.Levels.BloodWeapon && IsOffCooldown(DRK.BloodWeapon))
+                if (level >= DRK.Levels.BloodWeapon && IsCooldownUsable(DRK.BloodWeapon))
                     return OriginalHook(DRK.BloodWeapon);
             }
         }
@@ -213,7 +213,7 @@ internal class DarkQuietusBloodspiller : CustomCombo
 
             if (IsEnabled(CustomComboPreset.DarkLivingShadowFeature))
             {
-                if (level >= DRK.Levels.LivingShadow && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow))
+                if (level >= DRK.Levels.LivingShadow && gauge.Blood >= 50 && IsCooldownUsable(DRK.LivingShadow))
                     return DRK.LivingShadow;
             }
         }
@@ -234,13 +234,13 @@ internal class DarkLivingShadow : CustomCombo
 
             if (IsEnabled(CustomComboPreset.DarkLivingShadowbringerFeature))
             {
-                if (level >= DRK.Levels.Shadowbringer && gauge.ShadowTimeRemaining > 0 && HasCharges(DRK.Shadowbringer))
+                if (level >= DRK.Levels.Shadowbringer && gauge.ShadowTimeRemaining > 0 && IsCooldownUsable(DRK.Shadowbringer))
                     return DRK.Shadowbringer;
             }
 
             if (IsEnabled(CustomComboPreset.DarkLivingShadowbringerHpFeature))
             {
-                if (level >= DRK.Levels.Shadowbringer && HasCharges(DRK.Shadowbringer) && IsOnCooldown(DRK.LivingShadow))
+                if (level >= DRK.Levels.Shadowbringer && IsCooldownUsable(DRK.Shadowbringer) && !IsCooldownUsable(DRK.LivingShadow))
                     return DRK.Shadowbringer;
             }
         }

--- a/XIVComboExpanded/Combos/GNB.cs
+++ b/XIVComboExpanded/Combos/GNB.cs
@@ -166,7 +166,7 @@ internal class GunbreakerBurstStrikeFatedCircle : CustomCombo
 
             if (IsEnabled(CustomComboPreset.GunbreakerDoubleDownFeature))
             {
-                if (level >= GNB.Levels.DoubleDown && gauge.Ammo >= 2 && IsOffCooldown(GNB.DoubleDown))
+                if (level >= GNB.Levels.DoubleDown && gauge.Ammo >= 2 && IsCooldownUsable(GNB.DoubleDown))
                     return GNB.DoubleDown;
             }
 
@@ -245,7 +245,7 @@ internal class GunbreakerNoMercy : CustomCombo
             {
                 if (level >= GNB.Levels.NoMercy && HasEffect(GNB.Buffs.NoMercy))
                 {
-                    if (level >= GNB.Levels.DoubleDown && gauge.Ammo >= 2 && IsOffCooldown(GNB.DoubleDown))
+                    if (level >= GNB.Levels.DoubleDown && gauge.Ammo >= 2 && IsCooldownUsable(GNB.DoubleDown))
                         return GNB.DoubleDown;
                 }
             }

--- a/XIVComboExpanded/Combos/MCH.cs
+++ b/XIVComboExpanded/Combos/MCH.cs
@@ -138,9 +138,7 @@ internal class MachinistGaussRoundRicochet : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        var richochet = level < MCH.Levels.CheckMate ? MCH.Ricochet : MCH.Checkmate;
-        var gaussRound = level < MCH.Levels.DoubleCheck ? MCH.GaussRound : MCH.DoubleCheck;
-        if (actionID == MCH.GaussRound || actionID == richochet)
+        if (actionID == MCH.GaussRound || actionID == MCH.Ricochet)
         {
             var gauge = GetJobGauge<MCHGauge>();
 
@@ -151,9 +149,9 @@ internal class MachinistGaussRoundRicochet : CustomCombo
             }
 
             if (level >= MCH.Levels.Ricochet)
-                return CalcBestAction(actionID, gaussRound, richochet);
+                return OriginalHook(CalcBestAction(actionID, MCH.GaussRound, MCH.Ricochet));
 
-            return gaussRound;
+            return OriginalHook(MCH.Ricochet);
         }
 
         return actionID;
@@ -168,10 +166,10 @@ internal class MachinistWildfire : CustomCombo
     {
         if (actionID == MCH.Hypercharge)
         {
-            if (level >= MCH.Levels.Wildfire && IsOffCooldown(MCH.Wildfire) && HasTarget())
+            if (level >= MCH.Levels.Wildfire && IsCooldownUsable(MCH.Wildfire) && HasTarget())
                 return MCH.Wildfire;
 
-            if (level >= MCH.Levels.Wildfire && IsOnCooldown(MCH.Hypercharge) && !IsOriginal(MCH.Wildfire))
+            if (level >= MCH.Levels.Wildfire && !IsCooldownUsable(MCH.Hypercharge) && !IsOriginal(MCH.Wildfire))
                 return MCH.Detonator;
         }
 
@@ -191,7 +189,7 @@ internal class MachinistHeatBlastAutoCrossbow : CustomCombo
 
             if (IsEnabled(CustomComboPreset.MachinistHyperfireFeature))
             {
-                if (level >= MCH.Levels.Wildfire && IsOffCooldown(MCH.Wildfire) && HasTarget())
+                if (level >= MCH.Levels.Wildfire && IsCooldownUsable(MCH.Wildfire) && HasTarget())
                     return MCH.Wildfire;
             }
 

--- a/XIVComboExpanded/Combos/PCT.cs
+++ b/XIVComboExpanded/Combos/PCT.cs
@@ -304,7 +304,7 @@ internal static class PCT
                 {
                     if (gauge.MooglePortraitReady || gauge.MadeenPortraitReady)
                     {
-                        if (IsOffCooldown(PCT.MogOftheAges))
+                        if (IsCooldownUsable(PCT.MogOftheAges))
                             return OriginalHook(PCT.MogOftheAges);
                     }
                 }

--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -402,7 +402,7 @@ internal class PaladinShieldBash : PaladinCombo
     {
         if (actionID == PLD.ShieldBash)
         {
-            if (level >= PLD.Levels.LowBlow && IsOffCooldown(PLD.LowBlow))
+            if (level >= PLD.Levels.LowBlow && IsCooldownUsable(PLD.LowBlow))
                 return PLD.LowBlow;
         }
 

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -386,14 +386,14 @@ internal class RedMageAcceleration : CustomCombo
                 {
                     if (IsEnabled(CustomComboPreset.RedMageAccelerationSwiftcastOption))
                     {
-                        if (IsOffCooldown(RDM.Acceleration) && IsOffCooldown(ADV.Swiftcast))
+                        if (IsCooldownUsable(RDM.Acceleration) && IsCooldownUsable(ADV.Swiftcast))
                             return ADV.Swiftcast;
                     }
 
-                    if (IsOffCooldown(RDM.Acceleration))
+                    if (IsCooldownUsable(RDM.Acceleration))
                         return RDM.Acceleration;
 
-                    if (IsOffCooldown(ADV.Swiftcast))
+                    if (IsCooldownUsable(ADV.Swiftcast))
                         return ADV.Swiftcast;
                 }
 
@@ -416,7 +416,7 @@ internal class RedMageEmbolden : CustomCombo
     {
         if (actionID == RDM.Embolden)
         {
-            if (level >= RDM.Levels.Manafication && IsOffCooldown(RDM.Manafication) && !IsOffCooldown(RDM.Embolden))
+            if (level >= RDM.Levels.Manafication && IsCooldownUsable(RDM.Manafication) && !IsCooldownUsable(RDM.Embolden))
                 return RDM.Manafication;
         }
 

--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -361,7 +361,7 @@ internal class ReaperSoulSlice : CustomCombo
             {
                 if (IsEnabled(CustomComboPreset.ReaperBloodStalkGluttonyFeature))
                 {
-                    if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && gauge.EnshroudedTimeRemaining == 0 && IsOffCooldown(RPR.Gluttony))
+                    if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && gauge.EnshroudedTimeRemaining == 0 && IsCooldownUsable(RPR.Gluttony))
                         return RPR.Gluttony;
                 }
 
@@ -389,7 +389,7 @@ internal class ReaperSoulScythe : CustomCombo
             {
                 if (IsEnabled(CustomComboPreset.ReaperGrimSwatheGluttonyFeature))
                 {
-                    if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && gauge.EnshroudedTimeRemaining == 0 && IsOffCooldown(RPR.Gluttony))
+                    if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && gauge.EnshroudedTimeRemaining == 0 && IsCooldownUsable(RPR.Gluttony))
                         return RPR.Gluttony;
                 }
 
@@ -414,7 +414,7 @@ internal class ReaperBloodStalk : CustomCombo
 
             if (IsEnabled(CustomComboPreset.ReaperBloodStalkGluttonyFeature))
             {
-                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsOffCooldown(RPR.Gluttony) && gauge.EnshroudedTimeRemaining == 0)
+                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsCooldownUsable(RPR.Gluttony) && gauge.EnshroudedTimeRemaining == 0)
                     return RPR.Gluttony;
             }
 
@@ -441,7 +441,7 @@ internal class ReaperGrimSwathe : CustomCombo
 
             if (IsEnabled(CustomComboPreset.ReaperGrimSwatheGluttonyFeature))
             {
-                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsOffCooldown(RPR.Gluttony) && gauge.EnshroudedTimeRemaining == 0)
+                if (level >= RPR.Levels.Gluttony && gauge.Soul >= 50 && IsCooldownUsable(RPR.Gluttony) && gauge.EnshroudedTimeRemaining == 0)
                     return RPR.Gluttony;
             }
 

--- a/XIVComboExpanded/Combos/SAM.cs
+++ b/XIVComboExpanded/Combos/SAM.cs
@@ -294,12 +294,12 @@ internal class SamuraiShinten : CustomCombo
 
             if (IsEnabled(CustomComboPreset.SamuraiShintenSeneiFeature))
             {
-                if (level >= SAM.Levels.HissatsuSenei && IsOffCooldown(SAM.HissatsuSenei))
+                if (level >= SAM.Levels.HissatsuSenei && IsCooldownUsable(SAM.HissatsuSenei))
                     return SAM.HissatsuSenei;
 
                 if (IsEnabled(CustomComboPreset.SamuraiSeneiGurenFeature))
                 {
-                    if (level >= SAM.Levels.HissatsuGuren && level < SAM.Levels.HissatsuSenei && IsOffCooldown(SAM.HissatsuGuren))
+                    if (level >= SAM.Levels.HissatsuGuren && level < SAM.Levels.HissatsuSenei && IsCooldownUsable(SAM.HissatsuGuren))
                         return SAM.HissatsuGuren;
                 }
             }
@@ -340,7 +340,7 @@ internal class SamuraiKyuten : CustomCombo
 
             if (IsEnabled(CustomComboPreset.SamuraiKyutenGurenFeature))
             {
-                if (level >= SAM.Levels.HissatsuGuren && IsOffCooldown(SAM.HissatsuGuren))
+                if (level >= SAM.Levels.HissatsuGuren && IsCooldownUsable(SAM.HissatsuGuren))
                     return SAM.HissatsuGuren;
             }
         }

--- a/XIVComboExpanded/Combos/SCH.cs
+++ b/XIVComboExpanded/Combos/SCH.cs
@@ -91,13 +91,13 @@ internal class ScholarExcogitation : CustomCombo
         {
             if (IsEnabled(CustomComboPreset.ScholarExcogitationRecitationFeature))
             {
-                if (level >= SCH.Levels.Recitation && IsOffCooldown(SCH.Recitation))
+                if (level >= SCH.Levels.Recitation && IsCooldownUsable(SCH.Recitation))
                     return SCH.Recitation;
             }
 
             if (IsEnabled(CustomComboPreset.ScholarExcogitationLustrateFeature))
             {
-                if (level < SCH.Levels.Excogitation || IsOnCooldown(SCH.Excogitation))
+                if (level < SCH.Levels.Excogitation || !IsCooldownUsable(SCH.Excogitation))
                     return SCH.Lustrate;
             }
         }
@@ -136,13 +136,13 @@ internal class ScholarLustrate : CustomCombo
 
             if (IsEnabled(CustomComboPreset.ScholarLustrateRecitationFeature))
             {
-                if (level >= SCH.Levels.Recitation && IsOffCooldown(SCH.Recitation))
+                if (level >= SCH.Levels.Recitation && IsCooldownUsable(SCH.Recitation))
                     return SCH.Recitation;
             }
 
             if (IsEnabled(CustomComboPreset.ScholarLustrateExcogitationFeature))
             {
-                if (level >= SCH.Levels.Excogitation && IsOffCooldown(SCH.Excogitation))
+                if (level >= SCH.Levels.Excogitation && IsCooldownUsable(SCH.Excogitation))
                     return SCH.Excogitation;
             }
 

--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -108,7 +108,7 @@ internal class SageToxikon : CustomCombo
                     level >= SGE.Levels.Phlegma2 ? SGE.Phlegma2 :
                     level >= SGE.Levels.Phlegma ? SGE.Phlegma : 0;
 
-                if (phlegma != 0 && HasCharges(phlegma))
+                if (phlegma != 0 && IsCooldownUsable(phlegma))
                     return OriginalHook(SGE.Phlegma);
             }
         }
@@ -127,7 +127,7 @@ internal class SageSoteria : CustomCombo
         {
             if (IsEnabled(CustomComboPreset.SageSoteriaKardionFeature))
             {
-                if (!HasEffect(SGE.Buffs.Kardion) && IsOffCooldown(SGE.Soteria))
+                if (!HasEffect(SGE.Buffs.Kardion) && IsCooldownUsable(SGE.Soteria))
                     return SGE.Kardia;
             }
         }
@@ -154,7 +154,7 @@ internal class SageTaurochole : CustomCombo
 
             if (IsEnabled(CustomComboPreset.SageTaurocholeDruocholeFeature))
             {
-                if (level >= SGE.Levels.Taurochole && IsOffCooldown(SGE.Taurochole))
+                if (level >= SGE.Levels.Taurochole && IsCooldownUsable(SGE.Taurochole))
                     return SGE.Taurochole;
 
                 return SGE.Druochole;
@@ -183,7 +183,7 @@ internal class SageDruochole : CustomCombo
 
             if (IsEnabled(CustomComboPreset.SageDruocholeTaurocholeFeature))
             {
-                if (level >= SGE.Levels.Taurochole && IsOffCooldown(SGE.Taurochole))
+                if (level >= SGE.Levels.Taurochole && IsCooldownUsable(SGE.Taurochole))
                     return SGE.Taurochole;
             }
         }
@@ -257,7 +257,7 @@ internal class SagePhlegma : CustomCombo
                     level >= SGE.Levels.Phlegma2 ? SGE.Phlegma2 :
                     level >= SGE.Levels.Phlegma ? SGE.Phlegma : 0;
 
-                if (level >= SGE.Levels.Toxicon && phlegma != 0 && HasNoCharges(phlegma) && gauge.Addersting > 0)
+                if (level >= SGE.Levels.Toxicon && phlegma != 0 && !IsCooldownUsable(phlegma) && gauge.Addersting > 0)
                     return OriginalHook(SGE.Toxikon);
             }
 
@@ -268,7 +268,7 @@ internal class SagePhlegma : CustomCombo
                     level >= SGE.Levels.Phlegma2 ? SGE.Phlegma2 :
                     level >= SGE.Levels.Phlegma ? SGE.Phlegma : 0;
 
-                if (level >= SGE.Levels.Dyskrasia && phlegma != 0 && HasNoCharges(phlegma))
+                if (level >= SGE.Levels.Dyskrasia && phlegma != 0 && !IsCooldownUsable(phlegma))
                     return OriginalHook(SGE.Dyskrasia);
             }
         }

--- a/XIVComboExpanded/Combos/SMN.cs
+++ b/XIVComboExpanded/Combos/SMN.cs
@@ -258,7 +258,7 @@ internal class SummonerDemiFeature : CustomCombo
 
             if (IsEnabled(CustomComboPreset.SummonerDemiSearingLightFeature))
             {
-                if (level >= SMN.Levels.SearingLight && (gauge.IsBahamutReady || gauge.IsPhoenixReady) && InCombat() && IsOffCooldown(SMN.SearingLight))
+                if (level >= SMN.Levels.SearingLight && (gauge.IsBahamutReady || gauge.IsPhoenixReady) && InCombat() && IsCooldownUsable(SMN.SearingLight))
                     return SMN.SearingLight;
             }
 

--- a/XIVComboExpanded/Combos/VPR.cs
+++ b/XIVComboExpanded/Combos/VPR.cs
@@ -326,7 +326,7 @@ internal class DreadfangsDreadwinderFeature : CustomCombo
         if (actionID == VPR.DreadFangs)
         {
             // I think in this case if we're not in a combo (and something else isn't replacing Dread Fangs), we can just replace if we have charges
-            if (level >= VPR.Levels.Dreadwinder && IsOriginal(VPR.DreadFangs) && HasCharges(VPR.Dreadwinder) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
+            if (level >= VPR.Levels.Dreadwinder && IsOriginal(VPR.DreadFangs) && IsCooldownUsable(VPR.Dreadwinder) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
                 return VPR.Dreadwinder;
         }
 
@@ -342,7 +342,7 @@ internal class PitOfDreadFeature : CustomCombo
     {
         if (actionID == VPR.DreadMaw)
         {
-            if (level >= VPR.Levels.PitOfDread && IsOriginal(VPR.DreadMaw) && HasCharges(VPR.PitOfDread) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
+            if (level >= VPR.Levels.PitOfDread && IsOriginal(VPR.DreadMaw) && IsCooldownUsable(VPR.PitOfDread) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
                 return VPR.PitOfDread;
         }
 

--- a/XIVComboExpanded/Combos/WAR.cs
+++ b/XIVComboExpanded/Combos/WAR.cs
@@ -291,19 +291,19 @@ internal class WarriorBloodwhetting : CustomCombo
             {
                 if (level >= WAR.Levels.Bloodwhetting)
                 {
-                    if (IsOffCooldown(WAR.Bloodwhetting))
+                    if (IsCooldownUsable(WAR.Bloodwhetting))
                         return WAR.Bloodwhetting;
                 }
                 else if (level >= WAR.Levels.RawIntuition)
                 {
-                    if (IsOffCooldown(WAR.RawIntuition))
+                    if (IsCooldownUsable(WAR.RawIntuition))
                         return WAR.RawIntuition;
                 }
 
-                if (level >= WAR.Levels.ThrillOfBattle && IsOffCooldown(WAR.ThrillOfBattle))
+                if (level >= WAR.Levels.ThrillOfBattle && IsCooldownUsable(WAR.ThrillOfBattle))
                     return WAR.ThrillOfBattle;
 
-                if (level >= WAR.Levels.Equilibrium && IsOffCooldown(WAR.Equilibrium))
+                if (level >= WAR.Levels.Equilibrium && IsCooldownUsable(WAR.Equilibrium))
                     return WAR.Equilibrium;
             }
         }

--- a/XIVComboExpanded/CooldownData.cs
+++ b/XIVComboExpanded/CooldownData.cs
@@ -23,113 +23,31 @@ internal struct CooldownData
     private readonly float cooldownTotal;
 
     /// <summary>
-    /// Gets the base cooldown time in seconds.
-    /// </summary>
-    public float BaseCooldown => ActionManager.GetAdjustedRecastTime(ActionType.Action, this.ActionID) / 1000f;
-
-    /// <summary>
-    /// Gets the total cooldown calculated from AdjustedRecastTime in seconds.
-    /// </summary>
-    public float TotalBaseCooldown
-    {
-        get
-        {
-            var (cur, max) = Service.ComboCache.GetMaxCharges(this.ActionID);
-
-            // Rebase to the current charge count
-            var total = this.BaseCooldown / max * cur;
-
-            return total * cur;
-        }
-    }
-
-    /// <summary>
-    /// Gets the total cooldown time.
-    /// </summary>
-    public float CooldownTotal
-    {
-        get
-        {
-            if (this.cooldownTotal == 0)
-                return 0;
-
-            var (cur, max) = Service.ComboCache.GetMaxCharges(this.ActionID);
-            if (cur == max)
-                return this.cooldownTotal;
-
-            // Rebase to the current charge count
-            var total = this.cooldownTotal / max * cur;
-
-            if (this.cooldownElapsed > total)
-                return 0;
-
-            return total;
-        }
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether the action is on cooldown.
-    /// </summary>
-    public bool IsCooldown
-    {
-        get
-        {
-            return this.cooldownElapsed > 0 && this.cooldownElapsed < this.BaseCooldown;
-        }
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether all charges are capped.
-    /// </summary>
-    public bool IsCapped
-    {
-        get
-        {
-            return this.cooldownElapsed == 0;
-        }
-    }
-
-    /// <summary>
     /// Gets the action ID on cooldown.
     /// </summary>
     public uint ActionID => this.actionID;
 
     /// <summary>
-    /// Gets the elapsed cooldown time limited to an active charge (0 if a charge is available).
+    /// Gets the cast time in seconds, adjusted by spell cast time modifiers (ex. spell speed/skill speed).
     /// </summary>
-    public float CooldownElapsed
-    {
-        get
-        {
-            if (this.cooldownElapsed > this.BaseCooldown)
-                return 0;
-
-            return this.cooldownElapsed;
-        }
-    }
+    public unsafe float CastTime => ActionManager.GetAdjustedCastTime(ActionType.Action, this.ActionID) / 1000f;
 
     /// <summary>
-    /// Gets the elapsed cooldown time across the total cooldown (total cooldown time - total cooldown already regained).
+    /// Gets the resource cost of the action.
     /// </summary>
-    public float TotalCooldownElapsed => this.cooldownElapsed;
+    public unsafe float Cost => ActionManager.GetActionCost(ActionType.Action, this.ActionID, 1, 0, 0, 0);
 
     /// <summary>
-    /// Gets the cooldown time remaining until all charges are replenished.
+    /// Gets the base cooldown time of an action in seconds, adjusted for spell recast modifiers 
+    /// (ex. spell speed, if relevant)
     /// </summary>
-    public float TotalCooldownRemaining => this.TotalBaseCooldown - this.TotalCooldownElapsed;
+    public float BaseCooldown => ActionManager.GetAdjustedRecastTime(ActionType.Action, this.ActionID) / 1000f;
 
     /// <summary>
-    /// Gets the cooldown time remaining until the current cooldown has recovered.
+    /// Gets the total cooldown of an action across all charges, which is equivalent to the BaseCooldown multiplied
+    /// by the MaxCharges.
     /// </summary>
-    public float CooldownRemaining
-    {
-        get
-        {
-            var (cur, _) = Service.ComboCache.GetMaxCharges(this.ActionID);
-
-            return this.TotalCooldownRemaining % (this.TotalBaseCooldown / cur);
-        }
-    }
+    public float TotalBaseCooldown => this.BaseCooldown * this.MaxCharges;
 
     /// <summary>
     /// Gets the maximum number of charges for an action at the current level.
@@ -138,78 +56,53 @@ internal struct CooldownData
     public ushort MaxCharges => Service.ComboCache.GetMaxCharges(this.ActionID).Current;
 
     /// <summary>
-    /// Gets a value indicating whether the action has charges, not charges available.
+    /// Gets a value indicating whether an action utilizes charges, not whether charges are currently available.
     /// </summary>
-    public bool HasCharges => this.MaxCharges > 1;
+    public bool UsesCharges => this.MaxCharges > 1;
 
     /// <summary>
-    /// Gets the remaining number of charges for an action.
+    /// Gets the currently remaining (ie. usable) number of charges for an action.
     /// </summary>
-    public ushort RemainingCharges
-    {
-        get
-        {
-            var (cur, _) = Service.ComboCache.GetMaxCharges(this.ActionID);
-
-            if (this.TotalCooldownElapsed == 0)
-            {
-                return this.MaxCharges;
-            }
-
-            return (ushort)(this.TotalCooldownElapsed / (this.TotalBaseCooldown / this.MaxCharges));
-        }
-    }
+    public ushort RemainingCharges => !this.isCooldown ? this.MaxCharges : (ushort)(this.TotalCooldownElapsed / this.BaseCooldown);
 
     /// <summary>
-    /// Gets a value indicating whether gets value indicating whether this action has at least one charge out of however many it has total, even if it can only have one "charge".
+    /// Gets a value indicating whether this action is off cooldown, or for charge-based actions, if the action
+    /// has at least one usable charge available.
     /// </summary>
-    public bool Available => this.CooldownRemaining == 0 || this.RemainingCharges > 0;
+    public bool Available => !this.isCooldown || this.RemainingCharges > 0;
 
     /// <summary>
-    /// Gets the time since the cooldown was spent in seconds (only fuctional if actionID is not charge based).
+    /// Gets a value indicating whether the action is on cooldown, or for charge-based actions, if any charges
+    /// are currently recharging.  IsCooldown being true is NOT the same as the action being unavailable, as a
+    /// charged-based action can be both currently recovering a charge and also available for use.
     /// </summary>
-    public float CooldownDuration => this.BaseCooldown - this.CooldownRemaining;
+    public bool IsCooldown => this.isCooldown;
 
     /// <summary>
-    /// Gets the cooldown time remaining until the next charge.
+    /// Gets the cooldown time remaining until all charges are replenished.
     /// </summary>
-    public float ChargeCooldownRemaining
-    {
-        get
-        {
-            var (cur, _) = Service.ComboCache.GetMaxCharges(this.ActionID);
-
-            return this.TotalCooldownRemaining % (this.TotalBaseCooldown / cur);
-        }
-    }
+    public float TotalCooldownRemaining => !this.isCooldown ? 0 : this.TotalBaseCooldown - this.cooldownElapsed;
 
     /// <summary>
-    /// Gets the recovery time in seconds if action is used when cooldown is off.
+    /// Gets the cooldown time remaining until the currently recharging charge is replenished.  For actions that are
+    /// not charge-based, this is mechanically equivalent to TotalCooldownRemaining.
     /// </summary>
-    public float RecoveryTime => this.CooldownRemaining + this.BaseCooldown;
+    public float CooldownRemaining => this.TotalCooldownRemaining % this.BaseCooldown;
 
     /// <summary>
-    /// Gets the time until another charge is available after using the currently refreshing charge.
+    /// Gets the overall elapsed cooldown.  The value will range from 0, immediately after all charges are used, 
+    /// up to the TotalBaseCooldown.  It is not known at this time if a return value of exactly 0 is possible.
+    /// For abilities with charges, this will equal the time elapsed on the current charge's recharge, plus the
+    /// BaseCooldown multiplied by the number of charges currently available.
+    /// As an example, if an ability with 2 charges and a 20s recharge had 1 charge used 5 seconds ago
+    /// (so it has 1 charge available, and 15s remaining until another charge is available), this field would
+    /// return 25s (20 + 5).  If another charge were used at that exact moment, it would then return 5.
     /// </summary>
-    public float ChargeRecoveryTime
-    {
-        get
-        {
-            if ((this.RemainingCharges - 1) >= 0)
-            {
-                return this.ChargeCooldownRemaining;
-            }
-
-            return this.ChargeCooldownRemaining + this.BaseCooldown;
-        }
-    }
+    public float TotalCooldownElapsed => !this.isCooldown ? this.TotalBaseCooldown : this.cooldownElapsed;
 
     /// <summary>
-    /// Gets the cooldown time remaining until all charges of ability are replenished.
+    /// Gets the elapsed time on the recharge of only the currently recharging charge.  For actions that are not
+    /// charge-based, this is mechanically equivalent to TotalCooldownElapsed.
     /// </summary>
-    public float TotalChargeCooldownRemaining => this.MaxCharges - this.RemainingCharges > 0
-            ? this.MaxCharges - this.RemainingCharges == 1
-                ? this.ChargeCooldownRemaining
-                : (this.BaseCooldown * ((this.MaxCharges - this.RemainingCharges) - 1)) + this.ChargeCooldownRemaining
-            : 0;
+    public float CooldownElapsed => this.TotalCooldownElapsed % this.BaseCooldown;
 }


### PR DESCRIPTION
- Revamped CooldownData, based on prior work by and with significant input from @vitharr137.
  - Removed a number of not currently useful functions, which can be replicated by remaining functions anyway.
  - Updated the mechanics of a number of the CooldownData functions.  Full change details can be found at:
  - https://github.com/MKhayle/XIVComboExpanded/issues/305#issuecomment-2226556969
- Renamed `IsOffCooldown` to `IsCooldownUsable`, and clarified its semantics with regards to charge-based actions.
- Removed the global functions `HasCharges`, `HasNoCharges`, and `IsOnCooldown`.
  - All prior usages of these have been replaced with `IsCooldownUsable`.
- Added new function `IsRecharging`, which returns whether an ability is below maximum charges, without regard to whether it is usable currently.
- Fixed a bug preventing the icon replacement if Ricochet (and its upgrade Checkmate).
- As a side effect, fixes the action selection instability in #305, and probably a few other related bugs.

Fixes #305