### PR TITLE
[FEATURE] Automatic Saber Dance

### DIFF
--- a/XIVComboExpanded/Combos/DNC.cs
+++ b/XIVComboExpanded/Combos/DNC.cs
@@ -54,11 +54,14 @@ internal static class DNC
             SilkenSymmetry = 2693,
             SilkenFlow = 2694,
             StandardStep = 1818,
+            StandardFinish = 1821,
             TechnicalStep = 1819,
+            TechnicalFinish = 1822,
             ThreefoldFanDance = 1820,
             FourfoldFanDance = 2699,
             LastDanceReady = 3867,
-            FinishingMoveReady = 3868;
+            FinishingMoveReady = 3868,
+            DanceOfTheDawnReady = 3869;
     }
 
     public static class Debuffs
@@ -83,11 +86,13 @@ internal static class DNC
             FanDance3 = 66,
             TechnicalStep = 70,
             Flourish = 72,
+            SaberDance = 76,
             Tillana = 82,
             FanDance4 = 86,
             StarfallDance = 90,
             LastDance = 92,
-            FinishingMove = 96;
+            FinishingMove = 96,
+            DanceOfTheDawn = 100;
     }
 }
 
@@ -252,6 +257,22 @@ internal class DancerCascadeFountain : CustomCombo
     {
         if (actionID == DNC.Cascade)
         {
+            var gauge = GetJobGauge<DNCGauge>();
+
+            if (level >= DNC.Levels.SaberDance && !HasEffect(DNC.Buffs.StandardStep) && !HasEffect(DNC.Buffs.TechnicalStep))
+            {
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetDanceOfTheDawn) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.DanceOfTheDawnReady))
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetSabreDance) && gauge.Esprit >= 85)
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetSabreDanceTech) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.TechnicalFinish))
+                    return OriginalHook(DNC.SaberDance);
+            }
+
             if (IsEnabled(CustomComboPreset.DancerSingleTargetMultibutton))
             {
                 if (level >= DNC.Levels.Fountainfall && (HasEffect(DNC.Buffs.FlourishingFlow) || HasEffect(DNC.Buffs.SilkenFlow)))
@@ -273,10 +294,45 @@ internal class DancerCascadeFountain : CustomCombo
 
         if (actionID == DNC.Fountain)
         {
+            var gauge = GetJobGauge<DNCGauge>();
+
+            if (level >= DNC.Levels.SaberDance && !HasEffect(DNC.Buffs.StandardStep) && !HasEffect(DNC.Buffs.TechnicalStep))
+            {
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetDanceOfTheDawn) && 
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.DanceOfTheDawnReady))
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetSabreDance) && gauge.Esprit >= 85)
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetSabreDanceTech) && 
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.TechnicalFinish))
+                    return OriginalHook(DNC.SaberDance);
+            }
+
             if (IsEnabled(CustomComboPreset.DancerSingleTargetProcs))
             {
                 if (level >= DNC.Levels.Fountainfall && (HasEffect(DNC.Buffs.FlourishingFlow) || HasEffect(DNC.Buffs.SilkenFlow)))
                     return DNC.Fountainfall;
+            }
+        }
+
+        if (actionID == DNC.ReverseCascade || actionID == DNC.Fountainfall)
+        {
+            var gauge = GetJobGauge<DNCGauge>();
+
+            if (level >= DNC.Levels.SaberDance && !HasEffect(DNC.Buffs.StandardStep) && !HasEffect(DNC.Buffs.TechnicalStep))
+            {
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetDanceOfTheDawn) && 
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.DanceOfTheDawnReady))
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetSabreDance) && gauge.Esprit >= 85)
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerSingleTargetSabreDanceTech) && 
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.TechnicalFinish))
+                    return OriginalHook(DNC.SaberDance);
             }
         }
 
@@ -292,6 +348,22 @@ internal class DancerWindmillBladeshower : CustomCombo
     {
         if (actionID == DNC.Windmill)
         {
+            var gauge = GetJobGauge<DNCGauge>();
+
+            if (level >= DNC.Levels.SaberDance && !HasEffect(DNC.Buffs.StandardStep) && !HasEffect(DNC.Buffs.TechnicalStep))
+            {
+                if (IsEnabled(CustomComboPreset.DancerAoeDanceOfTheDawn) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.DanceOfTheDawnReady))
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerAoeSabreDance) && gauge.Esprit >= 85)
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerAoeSabreDanceTech) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.TechnicalFinish))
+                    return OriginalHook(DNC.SaberDance);
+            }
+
             if (IsEnabled(CustomComboPreset.DancerAoeMultibutton))
             {
                 if (level >= DNC.Levels.Bloodshower && (HasEffect(DNC.Buffs.FlourishingFlow) || HasEffect(DNC.Buffs.SilkenFlow)))
@@ -313,10 +385,45 @@ internal class DancerWindmillBladeshower : CustomCombo
 
         if (actionID == DNC.Bladeshower)
         {
+            var gauge = GetJobGauge<DNCGauge>();
+
+            if (level >= DNC.Levels.SaberDance && !HasEffect(DNC.Buffs.StandardStep) && !HasEffect(DNC.Buffs.TechnicalStep))
+            {
+                if (IsEnabled(CustomComboPreset.DancerAoeDanceOfTheDawn) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.DanceOfTheDawnReady))
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerAoeSabreDance) && gauge.Esprit >= 85)
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerAoeSabreDanceTech) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.TechnicalFinish))
+                    return OriginalHook(DNC.SaberDance);
+            }
+
             if (IsEnabled(CustomComboPreset.DancerAoeProcs))
             {
                 if (level >= DNC.Levels.Bloodshower && (HasEffect(DNC.Buffs.FlourishingFlow) || HasEffect(DNC.Buffs.SilkenFlow)))
                     return DNC.Bloodshower;
+            }
+        }
+
+        if (actionID == DNC.RisingWindmill || actionID == DNC.Bloodshower)
+        {
+            var gauge = GetJobGauge<DNCGauge>();
+
+            if (level >= DNC.Levels.SaberDance && !HasEffect(DNC.Buffs.StandardStep) && !HasEffect(DNC.Buffs.TechnicalStep))
+            {
+                if (IsEnabled(CustomComboPreset.DancerAoeDanceOfTheDawn) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.DanceOfTheDawnReady))
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerAoeSabreDance) && gauge.Esprit >= 85)
+                    return OriginalHook(DNC.SaberDance);
+
+                if (IsEnabled(CustomComboPreset.DancerAoeSabreDanceTech) &&
+                    gauge.Esprit >= 50 && HasEffect(DNC.Buffs.TechnicalFinish))
+                    return OriginalHook(DNC.SaberDance);
             }
         }
 

--- a/XIVComboExpanded/Combos/VPR.cs
+++ b/XIVComboExpanded/Combos/VPR.cs
@@ -239,20 +239,17 @@ internal class AutoGenerationLegacies : CustomCombo
         if (actionID == VPR.Reawaken && HasEffect(VPR.Buffs.Reawakened))
         {
             var gauge = GetJobGauge<VPRGauge>();
-            var maxtribute = 4;
 
-            if (level == 100)
+            if (level >= VPR.Levels.Legacies)
             {
-                if (OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy)
-                    return VPR.FirstLegacy;
-                if (OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
-                    return VPR.SecondLegacy;
-                if (OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy)
-                    return VPR.ThirdLegacy;
-                if (OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
-                    return VPR.FourthLegacy;
+                if (OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy || 
+                    OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy ||
+                    OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy ||
+                    OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
+                    return OriginalHook(VPR.SerpentsTail);
             }
 
+            var maxtribute = 4;
             if (level >= VPR.Levels.Ouroboros)
                 maxtribute = 5;
             if (gauge.AnguineTribute == maxtribute)

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -312,19 +312,49 @@ public enum CustomComboPreset
     [CustomComboInfo("Flourishing Fan Dance 4", "Replace Flourish with Fan Dance 4 when available.", DNC.JobID)]
     DancerFlourishFan4Feature = 3808,
 
+    [SecretCustomCombo]
     [ConflictingCombos(DancerSingleTargetProcs)]
     [CustomComboInfo("Single Target Multibutton", "Replace Cascade with its procs and combos as they activate.", DNC.JobID)]
     DancerSingleTargetMultibutton = 3804,
 
+    [SecretCustomCombo]
     [ConflictingCombos(DancerSingleTargetMultibutton)]
     [CustomComboInfo("Single Target to Procs", "Replace Cascade and Fountain with Reverse Cascade and Fountainfall respectively when available.", DNC.JobID)]
     DancerSingleTargetProcs = 3811,
 
+    [SecretCustomCombo]
+    [CustomComboInfo("Single Target Saber Dance", "Replace Cascade, Reverse Cascade, Fountain, and Fountainfall with Saber Dance when at >= 85 Esprit.", DNC.JobID)]
+    DancerSingleTargetSabreDance = 3817,
+
+    [SecretCustomCombo]
+    [ParentCombo(DancerSingleTargetSabreDance)]
+    [CustomComboInfo("Single Target Saber Dance Tech Step", "Use Saber Dance at >= 50 Esprit during Technical Step.", DNC.JobID)]
+    DancerSingleTargetSabreDanceTech = 3818,
+
+    [SecretCustomCombo]
+    [CustomComboInfo("Single Target Dance of the Dawn", "Replace Cascade, Reverse Cascade, Fountain, and Fountainfall with Dance of the Dawn when available and >= 50 Esprit.", DNC.JobID)]
+    DancerSingleTargetDanceOfTheDawn = 3819,
+
+    [SecretCustomCombo]
     [CustomComboInfo("AoE Multibutton", "Replace Windmill with its procs and combos as they activate.", DNC.JobID)]
     DancerAoeMultibutton = 3805,
 
-    [CustomComboInfo("AoE to Procs", "Replace Windmill and Bladeshower with Rising Wiindmill and Bloodshower respectively when available.", DNC.JobID)]
+    [SecretCustomCombo]
+    [CustomComboInfo("AoE to Procs", "Replace Windmill and Bladeshower with Rising Windmill and Bloodshower respectively when available.", DNC.JobID)]
     DancerAoeProcs = 3812,
+
+    [SecretCustomCombo]
+    [CustomComboInfo("AoE Saber Dance", "Replace Windmill, Rising Windmill, Bladeshower, and Bloodshower with Saber Dance when at >= 85 Esprit.", DNC.JobID)]
+    DancerAoeSabreDance = 3820,
+
+    [SecretCustomCombo]
+    [ParentCombo(DancerAoeSabreDance)]
+    [CustomComboInfo("AoE Saber Dance Tech Step", "Use Saber Dance at >= 50 Esprit during Technical Step.", DNC.JobID)]
+    DancerAoeSabreDanceTech = 3821,
+
+    [SecretCustomCombo]
+    [CustomComboInfo("AoE Dance of the Dawn", "Replace Windmill, Rising Windmill, Bladeshower, and Bloodshower with Dance of the Dawn when available and >= 50 Esprit.", DNC.JobID)]
+    DancerAoeDanceOfTheDawn = 3822,
 
     [ConflictingCombos(DancerDanceStepCombo)]
     [CustomComboInfo(


### PR DESCRIPTION
- Implemented ST and AoE features to automatically replace the standard combo attacks with Saber Dance when at >= 85 Esprit.
- Implemented ST and AoE features to reduce this threshold to 50 when under Technical Step.
- Implemented feature to do the same with Dance of the Dawn when it is available and >= 50 Esprit.
- Adjusted Viper's AutoGenerationsLegaciesFeature to reference the level constants, use a bit more compact conditional.

Tested locally, except for the Dance of the Dawn feature, since my Dancer is only 90 atm.

Fixes #322 