### PR TITLE
[FEATURE] PvP Dread combo + oGCDs

### DIFF
--- a/XIVComboExpanded/Combos/VPR.cs
+++ b/XIVComboExpanded/Combos/VPR.cs
@@ -600,6 +600,18 @@ internal class PvPWinderComboFeature : CustomCombo
                     return VPR.Ouroboros;
             }
 
+            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+            {
+                if (HasEffect(VPR.Buffs.HuntersVenom))
+                    return VPR.TwinfangBite;
+                if (HasEffect(VPR.Buffs.SwiftskinsVenom))
+                    return VPR.TwinbloodBite;
+                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
+                    return VPR.TwinfangBite;
+                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
+                    return VPR.TwinbloodBite;
+            }
+
             if (IsEnabled(CustomComboPreset.ViperPvPWinderComboStartHuntersFeature))
             {
                 if (gauge.DreadCombo is DreadCombo.Dreadwinder and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
@@ -639,6 +651,18 @@ internal class PvPPitComboFeature : CustomCombo
             {
                 if (gauge.AnguineTribute == 1)
                     return VPR.Ouroboros;
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+            {
+                if (HasEffect(VPR.Buffs.FellhuntersVenom))
+                    return VPR.TwinfangThresh;
+                if (HasEffect(VPR.Buffs.FellskinsVenom))
+                    return VPR.TwinbloodThresh;
+                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
+                    return VPR.TwinfangThresh;
+                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
+                    return VPR.TwinbloodThresh;
             }
 
             if (IsEnabled(CustomComboPreset.ViperPvPPitComboStartHuntersFeature))

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1263,7 +1263,7 @@ public enum CustomComboPreset
     ViperTwinCoilFeature = 4103,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Twin Coil AoE Feature", "Replace Swiftskin's Den and Hunter's Den with their respective Twinblood and Twinfang skills.", VPR.JobID)]
+    [CustomComboInfo("Twin Den (AoE) Feature", "Replace Swiftskin's Den and Hunter's Den with their respective Twinblood and Twinfang skills.", VPR.JobID)]
     ViperTwinDenFeature = 4104,
 
     [SecretCustomCombo]


### PR DESCRIPTION
- When either of the PvP Dread combos are selected, as well as one of the Twin Coil features, the oGCD followups to the Coil/Den actions are also now included.
- Also renamed the `Twin Coil AoE feature` to `Twin Den (AoE) Feature`, since "Coil" are the single target actions.
- Fixes #328.