### PR TITLE
[FEATURE] Kyuten Shoha/Zanshin feature

### DIFF
--- a/XIVComboExpanded/Combos/SAM.cs
+++ b/XIVComboExpanded/Combos/SAM.cs
@@ -338,6 +338,18 @@ internal class SamuraiKyuten : CustomCombo
         {
             var gauge = GetJobGauge<SAMGauge>();
 
+            if (IsEnabled(CustomComboPreset.SamuraiKyutenZanshinFeature))
+            {
+                if (level >= SAM.Levels.Zanshin && HasEffect(SAM.Buffs.ZanshinReady))
+                    return SAM.Zanshin;
+            }
+
+            if (IsEnabled(CustomComboPreset.SamuraiKyutenShohaFeature))
+            {
+                if (level >= SAM.Levels.Shoha && gauge.MeditationStacks >= 3)
+                    return SAM.Shoha;
+            }
+
             if (IsEnabled(CustomComboPreset.SamuraiKyutenGurenFeature))
             {
                 if (level >= SAM.Levels.HissatsuGuren && IsCooldownUsable(SAM.HissatsuGuren))

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1139,11 +1139,14 @@ public enum CustomComboPreset
     [CustomComboInfo("Senei to Guren Level Sync", "Replace Hissatsu: Senei with Guren when level synced below 72.", SAM.JobID)]
     SamuraiSeneiGurenFeature = 3418,
 
+    [CustomComboInfo("Kyuten to Zanshin", "Replace Hissatsu: Kyuten with Zanshin when available.", SAM.JobID)]
+    SamuraiKyutenZanshinFeature = 3421,
+
+    [CustomComboInfo("Kyuten to Shoha", "Replace Hissatsu: Kyuten with Shoha when Meditation is full.", SAM.JobID)]
+    SamuraiKyutenShohaFeature = 3412,
+
     [CustomComboInfo("Kyuten to Guren", "Replace Hissatsu: Kyuten with Guren when available.", SAM.JobID)]
     SamuraiKyutenGurenFeature = 3415,
-
-    //[CustomComboInfo("Kyuten to Shoha II", "Replace Hissatsu: Kyuten with Shoha II when Meditation is full.", SAM.JobID)]
-    //SamuraiKyutenShoha2Feature = 3412,
 
     [CustomComboInfo("Ikishoten Namikiri Feature", "Replace Ikishoten with Ogi Namikiri and then Kaeshi Namikiri when available.", SAM.JobID)]
     SamuraiIkishotenNamikiriFeature = 3411,


### PR DESCRIPTION
- Re-implemented the Kyuten Shoha feature, using the new merged DT Shoha.
  - Uses the same combo ID as previously, so it should auto-re-enable for anyone that had it selected previously.
- Implemented a Kyuten Zanshin feature to mirror the Shinten Zanshin feature.