### PR TITLE
[DRAFT] Remove non-working GNB combo, add new Continuation style combo

### DIFF
--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -475,9 +475,9 @@ public enum CustomComboPreset
     [CustomComboInfo("Fated Circle Continuation", "Replace Fated Circle with Continuation moves when appropriate.", GNB.JobID)]
     GunbreakerFatedCircleCont = 3714,
 
-    [SecretCustomCombo]
-    [CustomComboInfo("Sonic Shock Feature", "Replace Bow Shock and Sonic Break with one or the other depending on which is on cooldown.", GNB.JobID)]
-    GunbreakerBowShockSonicBreakFeature = 3704,
+    // [SecretCustomCombo]
+    // [CustomComboInfo("Sonic Shock Feature", "Replace Bow Shock and Sonic Break with one or the other depending on which is on cooldown.", GNB.JobID)]
+    // GunbreakerBowShockSonicBreakFeature = 3704,
 
     [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID)]
     GunbreakerDemonSlaughterCombo = 3705,
@@ -503,6 +503,13 @@ public enum CustomComboPreset
     [SecretCustomCombo]
     [CustomComboInfo("Double Down Feature", "Replace Burst Strike and Fated Circle with Double Down when available.", GNB.JobID)]
     GunbreakerDoubleDownFeature = 3709,
+
+    [SecretCustomCombo]
+    [CustomComboInfo("Expanded Continuation Feature", "Replace Continuation with several abilities, giving a continuation-like followup to several abilities.\nCombo Danger Zone after Keen Edge or Brutal Shell\nCombo Sonic Break after No Mercy\nFollow up Solid Barrel with Double Down, Gnashing Fang combo, or Burst Strike\nFollow up Demon Slaughter with Double Down or Fated Circle\nFollow up Bloodfest with the Reign combo", GNB.JobID)]
+    GunbreakerExpandedContinuation = 3715,
+
+    [CustomComboInfo("Trajectory downgrade when level capped", "Replaces Trajectory with Lightning Shot when below level for it.", GNB.JobID)]
+    GunbreakerTrajectoryDowngradeFeature = 3716,
 
     #endregion
     // ====================================================================================


### PR DESCRIPTION
Ok, hear meow-t

I was thinking on what might make GNB more interesting, and landed on a VPR-style continuation thing for their continuation ability. It collapses a bunch of stuff onto continuation, like Burst Strike/Fated Circle, which kind of make sense to follow up their base abilities.

I marked it secret, since it does a fair amount of stuff, but wdyt?

(Also removed that Sonic Break/Bow Shock thing, since Sonic Break is now a followup to No Mercy, and that's how it works in this feature as well)