### PR TITLE
Fix for pre-Communio ReaperSliceEnhancedEnshroudedFeature

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -142,7 +142,7 @@ internal class ReaperSlice : CustomCombo
                 (level >= RPR.Levels.Executioner && HasEffect(RPR.Buffs.Executioner)) ||
                 (level >= RPR.Levels.Enshroud && gauge.EnshroudedTimeRemaining > 0))
             {
-                if (IsEnabled(CustomComboPreset.ReaperSliceEnhancedEnshroudedFeature))
+                if (IsEnabled(CustomComboPreset.ReaperSliceEnhancedEnshroudedFeature) && HasEffect(RPR.Buffs.Enshrouded))
                 {
                     if (HasEffect(RPR.Buffs.EnhancedVoidReaping))
                         return RPR.VoidReaping;


### PR DESCRIPTION
Pre-communio, the buff from Enhanced Reaping persists after shroud, so need to ensure we're in shroud here