### PR TITLE
[QUICKFIX] Paladin - Holy Spirit under Requiescat

### DIFF
--- a/XIVComboExpanded/Combos/PLD.cs
+++ b/XIVComboExpanded/Combos/PLD.cs
@@ -168,9 +168,12 @@ internal class PaladinRoyalAuthority : PaladinCombo
                             return OriginalHook(PLD.Atonement);
                     }
 
-                    if ((HasEffect(PLD.Buffs.DivineMight) || HasEffect(PLD.Buffs.Requiescat)) && this.HasMp(PLD.HolySpirit))
+                    if (HasEffect(PLD.Buffs.DivineMight) && this.HasMp(PLD.HolySpirit))
                         return PLD.HolySpirit;
                 }
+
+                if (HasEffect(PLD.Buffs.Requiescat) && this.HasMp(PLD.HolySpirit))
+                    return PLD.HolySpirit;
             }
 
             if (level >= PLD.Levels.Atonement && IsEnabled(CustomComboPreset.PaladinRoyalAuthorityAtonementComboFeature))


### PR DESCRIPTION
- Holy Spirit is now prioritized if Requiescat is active even if Fight or Flight is not
  - This fixes an issue while leveling and below the level where the full Confiteor combo is acquired, where one or more stacks of Req may still be active after FoF ends.

Fixes #356 