### PR TITLE
[FEATURE] Viper Rewrite

### DIFF
--- a/XIVComboExpanded/Combos/VPR.cs
+++ b/XIVComboExpanded/Combos/VPR.cs
@@ -1,6 +1,5 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
-
-using DreadCombo = Dalamud.Game.ClientState.JobGauge.Enums.DreadCombo;
+﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Types;
 
 namespace XIVComboExpandedPlugin.Combos;
 
@@ -25,10 +24,10 @@ internal static class VPR
             JaggedMaw = 34618,
             BloodiedMaw = 34619,
 
-            Dreadwinder = 34620,
+            Vicewinder = 34620,
             HuntersCoil = 34621,
             SwiftskinsCoil = 34622,
-            PitOfDread = 34623,
+            VicePit = 34623,
             HuntersDen = 34624,
             SwiftskinsDen = 34625,
 
@@ -107,365 +106,446 @@ internal static class VPR
             AoE3rdCombo = 50,    // Jagged Maw and Bloodied Maw
             DeathRattle = 55,
             LastLash = 60,
-            Dreadwinder = 65,    // Also includes Hunter's Coil and Swiftskin's Coil
-            PitOfDread = 70,     // Also includes Hunter's Den and Swiftskin's Den
+            Vicewinder = 65,     // Also includes Hunter's Coil and Swiftskin's Coil
+            VicePit = 70,        // Also includes Hunter's Den and Swiftskin's Den
             TwinsSingle = 75,    // Twinfang Bite and Twinblood Bite
             TwinsAoE = 80,       // Twinfang Thresh and Twinblood Thresh
             UncoiledFury = 82,
-            UncoiledTwins = 92,  // Uncoiled Twinfang and Uncoiled Twinblood
             SerpentsIre = 86,
             EnhancedRattle = 88, // Third stack of Rattling Coil can be accumulated
             Reawaken = 90,       // Also includes First Generation through Fourth Generation
-            Ouroboros = 96,
+            UncoiledTwins = 92,  // Uncoiled Twinfang and Uncoiled Twinblood
+            Ouroboros = 96,      // Also includes a 5th Anguine Tribute stack from Reawaken
             Legacies = 100;      // First through Fourth Legacy
     }
 }
 
-internal class AutoFangsFeature : CustomCombo
+internal class ViperFangs : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperAutoFangsFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if ((actionID == VPR.SteelFangs || actionID == VPR.ReavingFangs) && OriginalHook(VPR.SteelFangs) == VPR.SteelFangs)
-            return HasEffect(VPR.Buffs.HonedReavers) ? VPR.ReavingFangs : VPR.SteelFangs;
-
-        return actionID;
-    }
-}
-
-internal class AutoMawFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperAutoMawFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if ((actionID == VPR.SteelMaw || actionID == VPR.ReavingMaw) && OriginalHook(VPR.SteelMaw) == VPR.SteelMaw)
-            return HasEffect(VPR.Buffs.HonedReavers) ? VPR.ReavingMaw : VPR.SteelMaw;
-
-        return actionID;
-    }
-}
-
-internal class SteelTailFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperSteelTailFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.SteelFangs)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.DeathRattle)
-                return VPR.DeathRattle;
-        }
-
-        if (actionID == VPR.ReavingFangs)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.DeathRattle)
-                return VPR.DeathRattle;
-        }
-
-        return actionID;
-    }
-}
-
-internal class SteelTailAoEFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperSteelTailAoEFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.SteelMaw)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.LastLash)
-                return VPR.LastLash;
-        }
-
-        if (actionID == VPR.ReavingMaw)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.LastLash)
-                return VPR.LastLash;
-        }
-
-        return actionID;
-    }
-}
-
-internal class TwinCoilFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperTwinCoilFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.HuntersCoil)
-        {
-            if (HasEffect(VPR.Buffs.HuntersVenom))
-                return VPR.TwinfangBite;
-            if (HasEffect(VPR.Buffs.SwiftskinsVenom))
-                return VPR.TwinbloodBite;
-            if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
-                return VPR.TwinfangBite;
-            if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
-                return VPR.TwinbloodBite;
-        }
-
-        if (actionID == VPR.SwiftskinsCoil)
-        {
-            if (HasEffect(VPR.Buffs.HuntersVenom))
-                return VPR.TwinfangBite;
-            if (HasEffect(VPR.Buffs.SwiftskinsVenom))
-                return VPR.TwinbloodBite;
-            if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
-                return VPR.TwinfangBite;
-            if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
-                return VPR.TwinbloodBite;
-        }
-
-        return actionID;
-    }
-}
-
-internal class TwinDenFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperTwinDenFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.HuntersDen)
-        {
-            if (HasEffect(VPR.Buffs.FellhuntersVenom))
-                return VPR.TwinfangThresh;
-            if (HasEffect(VPR.Buffs.FellskinsVenom))
-                return VPR.TwinbloodThresh;
-            if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
-                return VPR.TwinfangThresh;
-            if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
-                return VPR.TwinbloodThresh;
-        }
-
-        if (actionID == VPR.SwiftskinsDen)
-        {
-            if (HasEffect(VPR.Buffs.FellhuntersVenom))
-                return VPR.TwinfangThresh;
-            if (HasEffect(VPR.Buffs.FellskinsVenom))
-                return VPR.TwinbloodThresh;
-            if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
-                return VPR.TwinfangThresh;
-            if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
-                return VPR.TwinbloodThresh;
-        }
-
-        return actionID;
-    }
-}
-
-internal class AutoGenerationLegacies : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperAutoGenerationsLegaciesFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.Reawaken && HasEffect(VPR.Buffs.Reawakened))
+        if (actionID == VPR.SteelFangs || actionID == VPR.ReavingFangs)
         {
             var gauge = GetJobGauge<VPRGauge>();
+            var maxtribute = level >= VPR.Levels.Ouroboros ? 5 : 4;
 
-            if (level >= VPR.Levels.Legacies)
+            if (IsEnabled(CustomComboPreset.ViperSteelTailFeature) && OriginalHook(VPR.SerpentsTail) == VPR.DeathRattle)
+                return VPR.DeathRattle;
+
+            if (IsEnabled(CustomComboPreset.ViperGenerationLegaciesFeature))
             {
-                if (OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy ||
-                    OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy ||
-                    OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy ||
-                    OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
-                    return OriginalHook(VPR.SerpentsTail);
+                if (actionID == VPR.SteelFangs && OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy)
+                    return VPR.FirstLegacy;
+
+                if (actionID == VPR.ReavingFangs && OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
+                    return VPR.SecondLegacy;
             }
 
-            var maxtribute = 4;
-            if (level >= VPR.Levels.Ouroboros)
-                maxtribute = 5;
-            if (gauge.AnguineTribute == maxtribute)
-                return VPR.FirstGeneration;
-            if (gauge.AnguineTribute == maxtribute - 1)
-                return VPR.SecondGeneration;
-            if (gauge.AnguineTribute == maxtribute - 2)
-                return VPR.ThirdGeneration;
-            if (gauge.AnguineTribute == maxtribute - 3)
-                return VPR.FourthGeneration;
-            if (gauge.AnguineTribute == 1 && level >= VPR.Levels.Ouroboros)
-                return VPR.Ouroboros;
+            if (IsEnabled(CustomComboPreset.ViperSteelCoilFeature))
+            {
+                if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+                {
+                    if (HasEffect(VPR.Buffs.HuntersVenom))
+                        return VPR.TwinfangBite;
+
+                    if (HasEffect(VPR.Buffs.SwiftskinsVenom))
+                        return VPR.TwinbloodBite;
+
+                    if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
+                        return VPR.TwinfangBite;
+
+                    if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
+                        return VPR.TwinbloodBite;
+                }
+
+                if (actionID == VPR.SteelFangs)
+                {
+                    if (gauge.AnguineTribute == maxtribute)
+                        return VPR.FirstGeneration;
+
+                    if (gauge.AnguineTribute == maxtribute - 2)
+                        return VPR.ThirdGeneration;
+
+                    if (CanUseAction(VPR.SwiftskinsCoil) && gauge.AnguineTribute == 0)
+                        return VPR.SwiftskinsCoil;
+                }
+
+                if (actionID == VPR.ReavingFangs)
+                {
+                    if (gauge.AnguineTribute >= 3 || (level < VPR.Levels.Ouroboros && gauge.AnguineTribute >= 2))
+                        return VPR.SecondGeneration;
+
+                    if (gauge.AnguineTribute > 0)
+                        return VPR.FourthGeneration;
+
+                    if (CanUseAction(VPR.HuntersCoil) && gauge.AnguineTribute == 0)
+                        return VPR.HuntersCoil;
+                }
             }
+
+            if (IsEnabled(CustomComboPreset.ViperAutoViceSTFeature) &&
+                level >= VPR.Levels.Vicewinder && IsOriginal(VPR.ReavingFangs) && 
+                IsCooldownUsable(VPR.Vicewinder) && IsOriginal(VPR.SerpentsTail))
+                return VPR.Vicewinder;
+
+            if (IsEnabled(CustomComboPreset.ViperAutoSteelReavingFeature) && OriginalHook(VPR.SteelFangs) == VPR.SteelFangs)
+                return HasEffect(VPR.Buffs.HonedReavers) ? VPR.ReavingFangs : VPR.SteelFangs;
+        }
 
         return actionID;
     }
 }
 
-internal class GenerationLegacies : CustomCombo
+internal class ViperMaws : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperGenerationLegaciesFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == VPR.SteelFangs)
+        if (actionID == VPR.SteelMaw || actionID == VPR.ReavingMaw)
         {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy)
-                return VPR.FirstLegacy;
-        }
+            var gauge = GetJobGauge<VPRGauge>();
+            var maxtribute = level >= VPR.Levels.Ouroboros ? 5 : 4;
 
-        if (actionID == VPR.ReavingFangs)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
-                return VPR.SecondLegacy;
-        }
+            if (IsEnabled(CustomComboPreset.ViperSteelTailFeature) && OriginalHook(VPR.SerpentsTail) == VPR.LastLash)
+                return VPR.LastLash;
 
-        if (actionID == VPR.HuntersCoil)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy)
-                return VPR.ThirdLegacy;
-        }
+            if (IsEnabled(CustomComboPreset.ViperGenerationLegaciesFeature))
+            {
+                if (actionID == VPR.SteelMaw && OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy)
+                    return VPR.FirstLegacy;
 
-        if (actionID == VPR.SwiftskinsCoil)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
-                return VPR.FourthLegacy;
+                if (actionID == VPR.ReavingMaw && OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
+                    return VPR.SecondLegacy;
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperSteelCoilFeature))
+            {
+                if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+                {
+                    if (HasEffect(VPR.Buffs.FellhuntersVenom))
+                        return VPR.TwinfangThresh;
+
+                    if (HasEffect(VPR.Buffs.FellskinsVenom))
+                        return VPR.TwinbloodThresh;
+
+                    if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
+                        return VPR.TwinfangThresh;
+
+                    if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
+                        return VPR.TwinbloodThresh;
+                }
+
+                if (actionID == VPR.SteelMaw)
+                {
+                    if (gauge.AnguineTribute == maxtribute)
+                        return VPR.FirstGeneration;
+
+                    if (gauge.AnguineTribute == maxtribute - 2)
+                        return VPR.ThirdGeneration;
+
+                    if (CanUseAction(VPR.SwiftskinsDen) && gauge.AnguineTribute == 0)
+                        return VPR.SwiftskinsDen;
+                }
+
+                if (actionID == VPR.ReavingMaw)
+                {
+                    if (gauge.AnguineTribute >= 3 || (level < VPR.Levels.Ouroboros && gauge.AnguineTribute >= 2))
+                        return VPR.SecondGeneration;
+
+                    if (gauge.AnguineTribute > 0)
+                        return VPR.FourthGeneration;
+
+                    if (CanUseAction(VPR.HuntersDen) && gauge.AnguineTribute == 0)
+                        return VPR.HuntersDen;
+                }
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperAutoViceAoEFeature) &&
+                level >= VPR.Levels.VicePit && IsOriginal(VPR.ReavingMaw) && 
+                IsCooldownUsable(VPR.VicePit) && IsOriginal(VPR.SerpentsTail))
+                return VPR.VicePit;
+
+            if (IsEnabled(CustomComboPreset.ViperAutoSteelReavingFeature) && OriginalHook(VPR.SteelMaw) == VPR.SteelMaw)
+                return HasEffect(VPR.Buffs.HonedReavers) ? VPR.ReavingMaw : VPR.SteelMaw;
         }
 
         return actionID;
     }
 }
 
-internal class GenerationLegaciesAoE : CustomCombo
+internal class ViperCoils : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperGenerationLegaciesAoEFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == VPR.SteelMaw)
+        if (actionID == VPR.HuntersCoil || actionID == VPR.SwiftskinsCoil)
         {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.FirstLegacy)
-                return VPR.FirstLegacy;
-        }
+            if (IsEnabled(CustomComboPreset.ViperGenerationLegaciesFeature))
+            {
+                if (actionID == VPR.HuntersCoil && OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy)
+                    return VPR.ThirdLegacy;
 
-        if (actionID == VPR.ReavingMaw)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
-                return VPR.SecondLegacy;
-        }
+                if (actionID == VPR.SwiftskinsCoil && OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
+                    return VPR.FourthLegacy;
+            }
 
-        if (actionID == VPR.HuntersDen)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy)
-                return VPR.ThirdLegacy;
-        }
+            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+            {
+                if (HasEffect(VPR.Buffs.HuntersVenom))
+                    return VPR.TwinfangBite;
 
-        if (actionID == VPR.SwiftskinsDen)
-        {
-            if (OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
-                return VPR.FourthLegacy;
+                if (HasEffect(VPR.Buffs.SwiftskinsVenom))
+                    return VPR.TwinbloodBite;
+
+                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
+                    return VPR.TwinfangBite;
+
+                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
+                    return VPR.TwinbloodBite;
+            }
         }
 
         return actionID;
     }
 }
 
-internal class UncoiledFollowupFeature : CustomCombo
+internal class ViperDens : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperUncoiledFollowupFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == VPR.HuntersDen || actionID == VPR.SwiftskinsDen)
+        {
+            if (IsEnabled(CustomComboPreset.ViperGenerationLegaciesFeature))
+            {
+                if (actionID == VPR.HuntersDen && OriginalHook(VPR.SerpentsTail) == VPR.ThirdLegacy)
+                    return VPR.ThirdLegacy;
+
+                if (actionID == VPR.SwiftskinsDen && OriginalHook(VPR.SerpentsTail) == VPR.FourthLegacy)
+                    return VPR.FourthLegacy;
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+            {
+                if (HasEffect(VPR.Buffs.FellhuntersVenom))
+                    return VPR.TwinfangThresh;
+
+                if (HasEffect(VPR.Buffs.FellskinsVenom))
+                    return VPR.TwinbloodThresh;
+
+                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
+                    return VPR.TwinfangThresh;
+
+                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
+                    return VPR.TwinbloodThresh;
+            }
+        }
+
+        return actionID;
+    }
+}
+
+internal class ViperUncoiled : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
         if (actionID == VPR.UncoiledFury)
         {
-            // If I'm reading this right, it will always want to go in this order
-            if (OriginalHook(VPR.Twinfang) == VPR.UncoiledTwinfang && HasEffect(VPR.Buffs.PoisedForTwinfang))
-                return VPR.UncoiledTwinfang;
+            if (IsEnabled(CustomComboPreset.ViperUncoiledFollowupFeature))
+            {
+                if (OriginalHook(VPR.Twinfang) == VPR.UncoiledTwinfang && HasEffect(VPR.Buffs.PoisedForTwinfang))
+                    return VPR.UncoiledTwinfang;
 
-            if (level >= VPR.Levels.UncoiledTwins && OriginalHook(VPR.Twinblood) == VPR.UncoiledTwinblood)
-                return VPR.UncoiledTwinblood;
+                if (OriginalHook(VPR.Twinblood) == VPR.UncoiledTwinblood)
+                    return VPR.UncoiledTwinblood;
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperFuryAndIreFeature) && level >= VPR.Levels.SerpentsIre) 
+            {
+                var gauge = GetJobGauge<VPRGauge>();
+                if (gauge.RattlingCoilStacks == 0)
+                    return VPR.SerpentsIre;
+            }
         }
 
         return actionID;
     }
 }
 
-internal class DreadfangsDreadwinderFeature : CustomCombo
+internal class ViperVicewinder : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperDreadfangsDreadwinderFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == VPR.ReavingFangs)
+        if (actionID == VPR.Vicewinder)
         {
-            // I think in this case if we're not in a combo (and something else isn't replacing Dread Fangs), we can just replace if we have charges
-            if (level >= VPR.Levels.Dreadwinder && IsOriginal(VPR.ReavingFangs) && IsCooldownUsable(VPR.Dreadwinder) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
-                return VPR.Dreadwinder;
+            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+            {
+                if (HasEffect(VPR.Buffs.HuntersVenom))
+                    return VPR.TwinfangBite;
+
+                if (HasEffect(VPR.Buffs.SwiftskinsVenom))
+                    return VPR.TwinbloodBite;
+
+                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
+                    return VPR.TwinfangBite;
+
+                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
+                    return VPR.TwinbloodBite;
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperPvPWinderComboFeature))
+            {
+                var gauge = GetJobGauge<VPRGauge>();
+                if (level >= VPR.Levels.Ouroboros && HasEffect(VPR.Buffs.Reawakened) && gauge.AnguineTribute == 1)
+                        return VPR.Ouroboros;
+
+                if (IsEnabled(CustomComboPreset.ViperPvPWinderComboStartHuntersFeature) && CanUseAction(VPR.HuntersCoil))
+                    return VPR.HuntersCoil;
+
+                if (CanUseAction(VPR.SwiftskinsCoil))
+                    return VPR.SwiftskinsCoil;
+
+                if (CanUseAction(VPR.HuntersCoil))
+                    return VPR.HuntersCoil;
+
+                return VPR.Vicewinder;
+            }
         }
 
         return actionID;
     }
 }
 
-internal class PitOfDreadFeature : CustomCombo
+internal class ViperVicepit : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperPitOfDreadFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == VPR.ReavingMaw)
+        if (actionID == VPR.VicePit)
         {
-            if (level >= VPR.Levels.PitOfDread && IsOriginal(VPR.ReavingMaw) && IsCooldownUsable(VPR.PitOfDread) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
-                return VPR.PitOfDread;
+            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
+            {
+                if (HasEffect(VPR.Buffs.FellhuntersVenom))
+                    return VPR.TwinfangThresh;
+
+                if (HasEffect(VPR.Buffs.FellskinsVenom))
+                    return VPR.TwinbloodThresh;
+
+                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
+                    return VPR.TwinfangThresh;
+
+                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
+                    return VPR.TwinbloodThresh;
+            }
+
+            if (IsEnabled(CustomComboPreset.ViperPvPPitComboFeature))
+            {
+                var gauge = GetJobGauge<VPRGauge>();
+                if (level >= VPR.Levels.Ouroboros && HasEffect(VPR.Buffs.Reawakened) && gauge.AnguineTribute == 1)
+                        return VPR.Ouroboros;
+
+                if (IsEnabled(CustomComboPreset.ViperPvPPitComboStartHuntersFeature) && CanUseAction(VPR.HuntersDen))
+                    return VPR.HuntersDen;
+
+                if (CanUseAction(VPR.SwiftskinsDen))
+                    return VPR.SwiftskinsDen;
+
+                if (CanUseAction(VPR.HuntersDen))
+                    return VPR.HuntersDen;
+
+                return VPR.VicePit;
+            }
         }
 
         return actionID;
     }
 }
 
-internal class MergeSerpentTwinsFeature : CustomCombo
+internal class ViperReawaken : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperMergeSerpentTwinsFeature;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == VPR.Reawaken)
+        {
+            if (IsEnabled(CustomComboPreset.ViperReawakenAIOFeature) && HasEffect(VPR.Buffs.Reawakened))
+            {
+                var gauge = GetJobGauge<VPRGauge>();
+
+                if (level >= VPR.Levels.Legacies)
+                {   
+                    var original = OriginalHook(VPR.SerpentsTail);
+                    if (original == VPR.FirstLegacy || 
+                        original == VPR.SecondLegacy ||
+                        original == VPR.ThirdLegacy ||
+                        original == VPR.FourthLegacy)
+                        return original;
+                }
+
+                var maxtribute = level >= VPR.Levels.Ouroboros ? 5 : 4;
+                if (gauge.AnguineTribute == maxtribute)
+                    return VPR.FirstGeneration;
+                if (gauge.AnguineTribute == maxtribute - 1)
+                    return VPR.SecondGeneration;
+                if (gauge.AnguineTribute == maxtribute - 2)
+                    return VPR.ThirdGeneration;
+                if (gauge.AnguineTribute == maxtribute - 3)
+                    return VPR.FourthGeneration;
+                if (gauge.AnguineTribute == 1 && level >= VPR.Levels.Ouroboros)
+                    return VPR.Ouroboros;
+            }
+        }
+
+        return actionID;
+    }
+}
+
+internal class ViperoGCDs : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VprAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
         if (actionID == VPR.SerpentsTail)
         {
-            if (!IsOriginal(VPR.SerpentsTail))
-                return OriginalHook(VPR.SerpentsTail);
+            if (IsEnabled(CustomComboPreset.ViperMergeSerpentTwinsFeature))
+            {
+                if (!IsOriginal(VPR.SerpentsTail))
+                    return OriginalHook(VPR.SerpentsTail);
 
-            if (HasEffect(VPR.Buffs.PoisedForTwinfang) || HasEffect(VPR.Buffs.HuntersVenom) || HasEffect(VPR.Buffs.FellhuntersVenom))
-                return OriginalHook(VPR.Twinfang);
+                if (HasEffect(VPR.Buffs.PoisedForTwinfang) || 
+                    HasEffect(VPR.Buffs.HuntersVenom) || 
+                    HasEffect(VPR.Buffs.FellhuntersVenom))
+                    return OriginalHook(VPR.Twinfang);
 
-            if (HasEffect(VPR.Buffs.PoisedForTwinblood) || HasEffect(VPR.Buffs.SwiftskinsVenom) || HasEffect(VPR.Buffs.FellskinsVenom))
-                return OriginalHook(VPR.Twinblood);
+                if (HasEffect(VPR.Buffs.PoisedForTwinblood) || 
+                    HasEffect(VPR.Buffs.SwiftskinsVenom) || 
+                    HasEffect(VPR.Buffs.FellskinsVenom))
+                    return OriginalHook(VPR.Twinblood);
 
-            if (!IsOriginal(VPR.Twinfang))
-                return OriginalHook(VPR.Twinfang);
+                if (!IsOriginal(VPR.Twinfang))
+                    return OriginalHook(VPR.Twinfang);
 
-            if (!IsOriginal(VPR.Twinblood))
-                return OriginalHook(VPR.Twinblood);
+                if (!IsOriginal(VPR.Twinblood))
+                    return OriginalHook(VPR.Twinblood);
+            }
         }
 
-        return actionID;
-    }
-}
-
-internal class MergeTwinsSerpentFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperMergeTwinsSerpentFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.Twinfang)
+        if (actionID == VPR.Twinfang || actionID == VPR.Twinblood)
         {
-            if (!IsOriginal(VPR.SerpentsTail))
+            if (IsEnabled(CustomComboPreset.ViperMergeTwinsSerpentFeature) && !IsOriginal(VPR.SerpentsTail))
                 return OriginalHook(VPR.SerpentsTail);
-
-            return OriginalHook(VPR.Twinfang);
-        }
-
-        if (actionID == VPR.Twinblood)
-        {
-            if (!IsOriginal(VPR.SerpentsTail))
-                return OriginalHook(VPR.SerpentsTail);
-
-            return OriginalHook(VPR.Twinblood);
         }
 
         return actionID;
@@ -613,126 +693,3 @@ internal class MergeTwinsSerpentFeature : CustomCombo
 //    }
 //}
 
-internal class PvPWinderComboFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperPvPWinderComboFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.Dreadwinder)
-        {
-            var gauge = GetJobGauge<VPRGauge>();
-            if (level >= VPR.Levels.Ouroboros && HasEffect(VPR.Buffs.Reawakened))
-            {
-                if (gauge.AnguineTribute == 1)
-                    return VPR.Ouroboros;
-            }
-
-            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
-            {
-                if (HasEffect(VPR.Buffs.HuntersVenom))
-                    return VPR.TwinfangBite;
-                if (HasEffect(VPR.Buffs.SwiftskinsVenom))
-                    return VPR.TwinbloodBite;
-                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangBite)
-                    return VPR.TwinfangBite;
-                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodBite)
-                    return VPR.TwinbloodBite;
-            }
-
-            if (IsEnabled(CustomComboPreset.ViperPvPWinderComboStartHuntersFeature))
-            {
-                if (gauge.DreadCombo is DreadCombo.Dreadwinder and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
-                    return VPR.HuntersCoil;
-                if (gauge.DreadCombo is DreadCombo.HuntersCoil and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
-                    return VPR.SwiftskinsCoil;
-                if (gauge.DreadCombo is DreadCombo.SwiftskinsCoil and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
-                    return VPR.Dreadwinder;
-
-                return VPR.Dreadwinder;
-            }
-
-            if (gauge.DreadCombo is DreadCombo.Dreadwinder and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
-                return VPR.SwiftskinsCoil;
-            if (gauge.DreadCombo is DreadCombo.SwiftskinsCoil and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
-                return VPR.HuntersCoil;
-            if (gauge.DreadCombo is DreadCombo.HuntersCoil and not DreadCombo.PitOfDread and not DreadCombo.HuntersDen and not DreadCombo.SwiftskinsDen)
-                return VPR.Dreadwinder;
-
-            return VPR.Dreadwinder;
-        }
-
-        return actionID;
-    }
-}
-
-internal class PvPPitComboFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperPvPPitComboFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.PitOfDread)
-        {
-            var gauge = GetJobGauge<VPRGauge>();
-            if (level >= VPR.Levels.Ouroboros && HasEffect(VPR.Buffs.Reawakened))
-            {
-                if (gauge.AnguineTribute == 1)
-                    return VPR.Ouroboros;
-            }
-
-            if (IsEnabled(CustomComboPreset.ViperTwinCoilFeature))
-            {
-                if (HasEffect(VPR.Buffs.FellhuntersVenom))
-                    return VPR.TwinfangThresh;
-                if (HasEffect(VPR.Buffs.FellskinsVenom))
-                    return VPR.TwinbloodThresh;
-                if (OriginalHook(VPR.Twinfang) == VPR.TwinfangThresh)
-                    return VPR.TwinfangThresh;
-                if (OriginalHook(VPR.Twinblood) == VPR.TwinbloodThresh)
-                    return VPR.TwinbloodThresh;
-            }
-
-            if (IsEnabled(CustomComboPreset.ViperPvPPitComboStartHuntersFeature))
-            {
-                if (gauge.DreadCombo is DreadCombo.PitOfDread and not DreadCombo.Dreadwinder and not DreadCombo.HuntersCoil and not DreadCombo.SwiftskinsCoil)
-                    return VPR.HuntersDen;
-                if (gauge.DreadCombo is DreadCombo.HuntersDen and not DreadCombo.Dreadwinder and not DreadCombo.HuntersCoil and not DreadCombo.SwiftskinsCoil)
-                    return VPR.SwiftskinsDen;
-                if (gauge.DreadCombo is DreadCombo.SwiftskinsDen and not DreadCombo.Dreadwinder and not DreadCombo.HuntersCoil and not DreadCombo.SwiftskinsCoil)
-                    return VPR.PitOfDread;
-
-                return VPR.PitOfDread;
-            }
-
-            if (gauge.DreadCombo is DreadCombo.PitOfDread and not DreadCombo.Dreadwinder and not DreadCombo.HuntersCoil and not DreadCombo.SwiftskinsCoil)
-                return VPR.SwiftskinsDen;
-            if (gauge.DreadCombo is DreadCombo.SwiftskinsDen and not DreadCombo.Dreadwinder and not DreadCombo.HuntersCoil and not DreadCombo.SwiftskinsCoil)
-                return VPR.HuntersDen;
-            if (gauge.DreadCombo is DreadCombo.HuntersDen and not DreadCombo.Dreadwinder and not DreadCombo.HuntersCoil and not DreadCombo.SwiftskinsCoil)
-                return VPR.PitOfDread;
-
-            return VPR.PitOfDread;
-        }
-
-        return actionID;
-    }
-}
-
-// TODO: Once Gauge is implemented
-internal class FuryAndIreFeature : CustomCombo
-{
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperFuryAndIreFeature;
-
-    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-    {
-        if (actionID == VPR.UncoiledFury && level >= VPR.Levels.UncoiledFury)
-        {
-            var gauge = GetJobGauge<VPRGauge>();
-            if (gauge.RattlingCoilStacks == 0)
-                return VPR.SerpentsIre;
-        }
-
-        return actionID;
-    }
-}

--- a/XIVComboExpanded/Combos/VPR.cs
+++ b/XIVComboExpanded/Combos/VPR.cs
@@ -10,7 +10,7 @@ internal static class VPR
 
     public const uint
             SteelFangs = 34606,
-            DreadFangs = 34607,
+            ReavingFangs = 34607,
             HuntersSting = 34608,
             SwiftskinsSting = 34609,
             FlankstingStrike = 34610,
@@ -19,7 +19,7 @@ internal static class VPR
             HindsbaneFang = 34613,
 
             SteelMaw = 34614,
-            DreadMaw = 34615,
+            ReavingMaw = 34615,
             HuntersBite = 34616,
             SwiftskinsBite = 34617,
             JaggedMaw = 34618,
@@ -79,13 +79,15 @@ internal static class VPR
             HuntersInstinct = 3668, // Double check, might also be 4120
             Swiftscaled = 3669,     // Might also be 4121
             Reawakened = 3670,
-            ReadyToReawaken = 3671;
+            ReadyToReawaken = 3671,
+            HonedSteel = 3672,
+            HonedReavers = 3772;
     }
 
     public static class Debuffs
     {
         public const ushort
-            NoxiousGash = 3667;
+            Placeholder = 0;
     }
 
     public static class Levels
@@ -93,12 +95,12 @@ internal static class VPR
         public const byte
             SteelFangs = 1,
             HuntersSting = 5,
-            DreadFangs = 10,
+            ReavingFangs = 10,
             WrithingSnap = 15,
             SwiftskinsSting = 20,
             SteelMaw = 25,
             Single3rdCombo = 30, // Includes Flanksting, Flanksbane, Hindsting, and Hindsbane
-            DreadMaw = 35,
+            ReavingMaw = 35,
             Slither = 40,
             HuntersBite = 40,
             SwiftskinsBike = 45,
@@ -119,6 +121,32 @@ internal static class VPR
     }
 }
 
+internal class AutoFangsFeature : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperAutoFangsFeature;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if ((actionID == VPR.SteelFangs || actionID == VPR.ReavingFangs) && OriginalHook(VPR.SteelFangs) == VPR.SteelFangs)
+            return HasEffect(VPR.Buffs.HonedReavers) ? VPR.ReavingFangs : VPR.SteelFangs;
+
+        return actionID;
+    }
+}
+
+internal class AutoMawFeature : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperAutoMawFeature;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if ((actionID == VPR.SteelMaw || actionID == VPR.ReavingMaw) && OriginalHook(VPR.SteelMaw) == VPR.SteelMaw)
+            return HasEffect(VPR.Buffs.HonedReavers) ? VPR.ReavingMaw : VPR.SteelMaw;
+
+        return actionID;
+    }
+}
+
 internal class SteelTailFeature : CustomCombo
 {
     protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ViperSteelTailFeature;
@@ -131,7 +159,7 @@ internal class SteelTailFeature : CustomCombo
                 return VPR.DeathRattle;
         }
 
-        if (actionID == VPR.DreadFangs)
+        if (actionID == VPR.ReavingFangs)
         {
             if (OriginalHook(VPR.SerpentsTail) == VPR.DeathRattle)
                 return VPR.DeathRattle;
@@ -153,7 +181,7 @@ internal class SteelTailAoEFeature : CustomCombo
                 return VPR.LastLash;
         }
 
-        if (actionID == VPR.DreadMaw)
+        if (actionID == VPR.ReavingMaw)
         {
             if (OriginalHook(VPR.SerpentsTail) == VPR.LastLash)
                 return VPR.LastLash;
@@ -281,7 +309,7 @@ internal class GenerationLegacies : CustomCombo
                 return VPR.FirstLegacy;
         }
 
-        if (actionID == VPR.DreadFangs)
+        if (actionID == VPR.ReavingFangs)
         {
             if (OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
                 return VPR.SecondLegacy;
@@ -315,7 +343,7 @@ internal class GenerationLegaciesAoE : CustomCombo
                 return VPR.FirstLegacy;
         }
 
-        if (actionID == VPR.DreadMaw)
+        if (actionID == VPR.ReavingMaw)
         {
             if (OriginalHook(VPR.SerpentsTail) == VPR.SecondLegacy)
                 return VPR.SecondLegacy;
@@ -363,10 +391,10 @@ internal class DreadfangsDreadwinderFeature : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == VPR.DreadFangs)
+        if (actionID == VPR.ReavingFangs)
         {
             // I think in this case if we're not in a combo (and something else isn't replacing Dread Fangs), we can just replace if we have charges
-            if (level >= VPR.Levels.Dreadwinder && IsOriginal(VPR.DreadFangs) && IsCooldownUsable(VPR.Dreadwinder) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
+            if (level >= VPR.Levels.Dreadwinder && IsOriginal(VPR.ReavingFangs) && IsCooldownUsable(VPR.Dreadwinder) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
                 return VPR.Dreadwinder;
         }
 
@@ -380,9 +408,9 @@ internal class PitOfDreadFeature : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (actionID == VPR.DreadMaw)
+        if (actionID == VPR.ReavingMaw)
         {
-            if (level >= VPR.Levels.PitOfDread && IsOriginal(VPR.DreadMaw) && IsCooldownUsable(VPR.PitOfDread) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
+            if (level >= VPR.Levels.PitOfDread && IsOriginal(VPR.ReavingMaw) && IsCooldownUsable(VPR.PitOfDread) && IsOriginal(VPR.SerpentsTail)) // Add the check for Serpent's Tail to avoid stepping on other combo
                 return VPR.PitOfDread;
         }
 
@@ -472,8 +500,8 @@ internal class MergeTwinsSerpentFeature : CustomCombo
 //            if (OriginalHook(VPR.SteelFangs) == VPR.SteelFangs)
 //            {
 //                var noxious = FindTargetEffect(VPR.Debuffs.NoxiousGash);
-//                if (level >= VPR.Levels.DreadFangs && (noxious is null || noxious?.RemainingTime < 12)) // 12s hopefully means we won't miss anything on a Reawaken window
-//                    return VPR.DreadFangs;
+//                if (level >= VPR.Levels.ReavingFangs && (noxious is null || noxious?.RemainingTime < 12)) // 12s hopefully means we won't miss anything on a Reawaken window
+//                    return VPR.ReavingFangs;
 
 //                return VPR.SteelFangs;
 //            }
@@ -546,8 +574,8 @@ internal class MergeTwinsSerpentFeature : CustomCombo
 //            if (OriginalHook(VPR.SteelMaw) == VPR.SteelMaw)
 //            {
 //                var noxious = FindTargetEffect(VPR.Debuffs.NoxiousGash); // TODO: Would be useful to handle the case with no target
-//                if (level >= VPR.Levels.DreadMaw && (noxious is null || noxious?.RemainingTime < 12)) // 12s hopefully means we won't miss anything on a Reawaken window
-//                    return VPR.DreadMaw;
+//                if (level >= VPR.Levels.ReavingMaw && (noxious is null || noxious?.RemainingTime < 12)) // 12s hopefully means we won't miss anything on a Reawaken window
+//                    return VPR.ReavingMaw;
 
 //                return VPR.SteelMaw;
 //            }

--- a/XIVComboExpanded/CustomCombo.cs
+++ b/XIVComboExpanded/CustomCombo.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
@@ -8,7 +5,8 @@ using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
 using Dalamud.Utility;
-using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using System;
+using System.Linq;
 using XIVComboExpandedPlugin.Attributes;
 
 namespace XIVComboExpandedPlugin.Combos;
@@ -108,7 +106,7 @@ internal abstract partial class CustomCombo
             (uint ActionID, CooldownData Data) a1,
             (uint ActionID, CooldownData Data) a2)
         {
-            // This intent of this priority algorithm is to generate a single unified number that results in the
+            // This intent of this priority algorithm is to generate a single unified number that results in the 
             // following behaviors:
             //   * Any ability that is off cooldown and at maximum charges has maximum (and equal) priority.
             //   * If only one of the two abilities is currently usable, it has a higher priority.
@@ -444,4 +442,11 @@ internal abstract partial class CustomCombo
 
         return true;
     }
+
+    /// <summary>
+    /// Gets bool determining if action is greyed out or not.
+    /// </summary>
+    /// <param name="actionID">Action ID.</param>
+    /// <returns>A bool value of whether the action can be used or not.</returns>
+    protected static bool CanUseAction(uint actionID) => Service.IconReplacer.CanUseAction(actionID);
 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1246,35 +1246,25 @@ public enum CustomComboPreset
     // ====================================================================================
     #region VIPER
 
-    [CustomComboInfo("Auto Fangs", "Replace Steel Fangs and Reaving Fangs with whichever is currently empowered. Only affects the first combo hit.", VPR.JobID)]
-    ViperAutoFangsFeature = 4124,
+    [CustomComboInfo("Auto Steel Reaving", "Replace Steel Fangs/Reaving Fangs and Steel Maw/Reaving Maw with whichever is currently empowered. Only affects the first combo hit.", VPR.JobID)]
+    ViperAutoSteelReavingFeature = 4124,
 
-    [CustomComboInfo("Auto Maw", "Replace Steel Maw and Reaving Maw with whichever is currently empowered.  Only affects the first combo hit", VPR.JobID)]
-    ViperAutoMawFeature = 4125,
-
-    [CustomComboInfo("Serpent's Fang Feature", "Replace Steel Fangs and Reaving Fangs with Serpent's Tail after finishing a combo.", VPR.JobID)]
+    [CustomComboInfo("Serpent's Fang Feature", "Replace Steel Fangs, Reaving Fangs, Steel Maw, and Reaving Maw with Serpent's Tail after finishing a combo.", VPR.JobID)]
     ViperSteelTailFeature = 4101,
 
-    [CustomComboInfo("Serpent's Maw (AoE) Feature", "Replace Steel Maw and Reaving Maw with Serpent's Tail after finishing a combo.", VPR.JobID)]
-    ViperSteelTailAoEFeature = 4102,
+    [CustomComboInfo("Steel Coil Feature", "Replace Steel Fangs with Swiftskin's Coil, Reaving Fangs with Hunter's Coil, Steel Maw with Swiftskin's Den, and Reaving Maw with Hunter's Den when usable.  Also replaces Steel Fangs/Maw with both First and Third Generation, and Reaving Fangs/Maw with both Second and Fourth.", VPR.JobID)]
+    ViperSteelCoilFeature = 4126,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Twin Coil Feature", "Replace Swiftskin's Coil and Hunter's Coil with their respective Twinblood and Twinfang skills.", VPR.JobID)]
+    [CustomComboInfo("Twin Coil Feature", "Replace Swiftskin's Coil/Den and Hunter's Coil/Den with their respective Twinblood and Twinfang skills.", VPR.JobID)]
     ViperTwinCoilFeature = 4103,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Twin Den (AoE) Feature", "Replace Swiftskin's Den and Hunter's Den with their respective Twinblood and Twinfang skills.", VPR.JobID)]
-    ViperTwinDenFeature = 4104,
-
-    [SecretCustomCombo]
     [CustomComboInfo("All-in-one Reawaken Feature", "Replace Reawaken by the Generation skills with their respective Legacies in order.", VPR.JobID)]
-    ViperAutoGenerationsLegaciesFeature = 4123,
+    ViperReawakenAIOFeature = 4123,
 
     [CustomComboInfo("Generation Legacy Feature", "Replaces the Generation skills with their respective Legacies.", VPR.JobID)]
     ViperGenerationLegaciesFeature = 4105,
-
-    [CustomComboInfo("Generation Legacy AoE Feature", "Replaces the AoE versions of Generation skills with their respective Legacies.", VPR.JobID)]
-    ViperGenerationLegaciesAoEFeature = 4106,
 
     [CustomComboInfo("Uncoiled Fury Followup", "Replaces Uncoiled Fury with Uncoiled Twinfang and Uncoiled Twinblood in sequence.", VPR.JobID)]
     ViperUncoiledFollowupFeature = 4107,
@@ -1283,12 +1273,12 @@ public enum CustomComboPreset
     ViperFuryAndIreFeature = 4108,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Reaving Fangs to Vicewinder", "Replaces Reaving Fangs to Vicewinder when charges are available and you're not currently in a combo.", VPR.JobID)]
-    ViperDreadfangsDreadwinderFeature = 4109,
+    [CustomComboInfo("Fangs to Vicewinder", "Replaces Steel Fangs and Reaving Fangs to Vicewinder when charges are available and you're not currently in a combo.", VPR.JobID)]
+    ViperAutoViceSTFeature = 4109,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Reaving Maw to Vicepit", "Replaces Reaving Maw with Vicepit when charges are available and not you're currently in a combo.", VPR.JobID)]
-    ViperPitOfDreadFeature = 4110,
+    [CustomComboInfo("Maws to Vicepit", "Replaces Steel Maw and Reaving Maw with Vicepit when charges are available and not you're currently in a combo.", VPR.JobID)]
+    ViperAutoViceAoEFeature = 4110,
 
     [ConflictingCombos(ViperMergeTwinsSerpentFeature)]
     [CustomComboInfo("Merge Twinfang/Twinblood onto Serpent's Tail Feature", "Merge all Twinfang/Twinblood abilities onto Serpent's Tail.", VPR.JobID)]
@@ -1298,61 +1288,52 @@ public enum CustomComboPreset
     [CustomComboInfo("Merge Serpent's Tail onto Twinfang/Twinblood Feature", "Merge all Serpent's Tail abilities onto Twinfang/Twinblood.", VPR.JobID)]
     ViperMergeTwinsSerpentFeature = 4112,
 
-    //[SecretCustomCombo]
-    //[ConflictingCombos(ViperSteelTailFeature)]
-    //[CustomComboInfo("Viper PvP Style Main Combo", "Condenses the main combo to a single button, like PvP.\nThe combo detects buffs and debuffs to prioritize skills.\nThe default combo ender is Hindsbane Fang, configurable below.", VPR.JobID)]
-    //ViperPvPMainComboFeature = 4113,
+    // [SecretCustomCombo]
+    // [ConflictingCombos(ViperSteelTailFeature)]
+    // [CustomComboInfo("Viper PvP Style Main Combo", "Condenses the main combo to a single button, like PvP.\nThe combo detects buffs and debuffs to prioritize skills.\nThe default combo ender is Hindsbane Fang, configurable below.", VPR.JobID)]
+    // ViperPvPMainComboFeature = 4113,
 
-    //[SecretCustomCombo]
-    //[ConflictingCombos(ViperPvPMainComboStartFlankstingFeature, ViperPvPMainComboStartHindstingFeature)]
-    //[ParentCombo(ViperPvPMainComboFeature)]
-    //[CustomComboInfo("PvP Combo Start Flanksbane Fang", "With no buffs, end first combo with Flanksbane Fang.", VPR.JobID)]
-    //ViperPvPMainComboStartFlanksbaneFeature = 4114,
+    // [SecretCustomCombo]
+    // [ConflictingCombos(ViperPvPMainComboStartFlankstingFeature, ViperPvPMainComboStartHindstingFeature)]
+    // [ParentCombo(ViperPvPMainComboFeature)]
+    // [CustomComboInfo("PvP Combo Start Flanksbane Fang", "With no buffs, end first combo with Flanksbane Fang.", VPR.JobID)]
+    // ViperPvPMainComboStartFlanksbaneFeature = 4114,
 
-    //[SecretCustomCombo]
-    //[ConflictingCombos(ViperPvPMainComboStartFlanksbaneFeature, ViperPvPMainComboStartHindstingFeature)]
-    //[ParentCombo(ViperPvPMainComboFeature)]
-    //[CustomComboInfo("PvP Combo Start Flanksting Strike", "With no buffs, end first combo with Flanksting Strike.", VPR.JobID)]
-    //ViperPvPMainComboStartFlankstingFeature = 4115,
+    // [SecretCustomCombo]
+    // [ConflictingCombos(ViperPvPMainComboStartFlanksbaneFeature, ViperPvPMainComboStartHindstingFeature)]
+    // [ParentCombo(ViperPvPMainComboFeature)]
+    // [CustomComboInfo("PvP Combo Start Flanksting Strike", "With no buffs, end first combo with Flanksting Strike.", VPR.JobID)]
+    // ViperPvPMainComboStartFlankstingFeature = 4115,
 
-    //[SecretCustomCombo]
-    //[ConflictingCombos(ViperPvPMainComboStartFlanksbaneFeature, ViperPvPMainComboStartFlankstingFeature)]
-    //[ParentCombo(ViperPvPMainComboFeature)]
-    //[CustomComboInfo("PvP Combo Start Hindsting Strike", "With no buffs, end first combo with Hindsting Strike.", VPR.JobID)]
-    //ViperPvPMainComboStartHindstingFeature = 4116,
+    // [SecretCustomCombo]
+    // [ConflictingCombos(ViperPvPMainComboStartFlanksbaneFeature, ViperPvPMainComboStartFlankstingFeature)]
+    // [ParentCombo(ViperPvPMainComboFeature)]
+    // [CustomComboInfo("PvP Combo Start Hindsting Strike", "With no buffs, end first combo with Hindsting Strike.", VPR.JobID)]
+    // ViperPvPMainComboStartHindstingFeature = 4116,
 
     // [SecretCustomCombo]
     // [ConflictingCombos(ViperSteelTailAoEFeature)]
     // [CustomComboInfo("Viper PvP Style AoE Combo", "Condenses the main combo to a single button, like PvP.\nThe combo can only detect debuffs on the current target.\nStarts with Jagged Maw by default, configurable below.", VPR.JobID)]
     // ViperPvPMainComboAoEFeature = 4117,
 
-    //[SecretCustomCombo]
-    //[ParentCombo(ViperPvPMainComboAoEFeature)]
-    //[CustomComboInfo("PvP AoE Combo Start Bloodied Maw", "With no buffs, end first combo with Bloodied Maw.", VPR.JobID)]
-    //ViperPvPMainComboAoEStartBloodiedFeature = 4118,
-
-    //[SecretCustomCombo]
-    //[ConflictingCombos(ViperSteelTailAoEFeature)]
-    //[CustomComboInfo("Viper PvP Style AoE Combo", "Condenses the main combo to a single button, like PvP.\nThe combo can only detect debuffs on the current target.\nStarts with Jagged Maw by default, configurable below.", VPR.JobID)]
-    //ViperPvPMainComboAoEFeature = 4117,
-
-    //[SecretCustomCombo]
-    //[ParentCombo(ViperPvPMainComboAoEFeature)]
-    //[CustomComboInfo("PvP AoE Combo Start Bloodied Maw", "With no buffs, end first combo with Bloodied Maw.", VPR.JobID)]
-    //ViperPvPMainComboAoEStartBloodiedFeature = 4118,
+    // [SecretCustomCombo]
+    // [ParentCombo(ViperPvPMainComboAoEFeature)]
+    // [CustomComboInfo("PvP AoE Combo Start Bloodied Maw", "With no buffs, end first combo with Bloodied Maw.", VPR.JobID)]
+    // ViperPvPMainComboAoEStartBloodiedFeature = 4118,
 
     [SecretCustomCombo]
-    [ConflictingCombos(ViperSteelTailFeature)]
-    [CustomComboInfo("Viper PvP Style Winder Combo", "Condenses the Dreadwinder combo to a single button, like PvP.\nStarts with Swiftskin's Coil by default.", VPR.JobID)]
+    [ConflictingCombos(ViperAutoViceSTFeature)]
+    [CustomComboInfo("Viper PvP Style Winder Combo", "Condenses the Vicewinder combo to a single button, like PvP.\nStarts with Swiftskin's Coil (rear positional) by default.", VPR.JobID)]
     ViperPvPWinderComboFeature = 4119,
 
     [SecretCustomCombo]
     [ParentCombo(ViperPvPWinderComboFeature)]
-    [CustomComboInfo("Start with Hunter's Coil", "Start with Hunter's Coil instead.", VPR.JobID)]
+    [CustomComboInfo("Start with Hunter's Coil", "Start with Hunter's Coil (flank positional) instead.", VPR.JobID)]
     ViperPvPWinderComboStartHuntersFeature = 4120,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Viper PvP Style Pit Combo", "Condenses the Pit of Dread combo to a single button, like PvP.\nStarts with Swiftskin's Den by default.", VPR.JobID)]
+    [ConflictingCombos(ViperAutoViceAoEFeature)]
+    [CustomComboInfo("Viper PvP Style Pit Combo", "Condenses the Vicepit combo to a single button, like PvP.\nStarts with Swiftskin's Den by default.", VPR.JobID)]
     ViperPvPPitComboFeature = 4121,
 
     [SecretCustomCombo]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1246,10 +1246,16 @@ public enum CustomComboPreset
     // ====================================================================================
     #region VIPER
 
-    [CustomComboInfo("Steel Tail Feature", "Replace Steel Fangs and Dread Fangs with Serpent's Tail after finishing a combo.", VPR.JobID)]
+    [CustomComboInfo("Auto Fangs", "Replace Steel Fangs and Reaving Fangs with whichever is currently empowered. Only affects the first combo hit.", VPR.JobID)]
+    ViperAutoFangsFeature = 4124,
+
+    [CustomComboInfo("Auto Maw", "Replace Steel Maw and Reaving Maw with whichever is currently empowered.  Only affects the first combo hit", VPR.JobID)]
+    ViperAutoMawFeature = 4125,
+
+    [CustomComboInfo("Serpent's Fang Feature", "Replace Steel Fangs and Reaving Fangs with Serpent's Tail after finishing a combo.", VPR.JobID)]
     ViperSteelTailFeature = 4101,
 
-    [CustomComboInfo("Steel Tail AoE Feature", "Replace Steel Maw and Dread Maw with Serpent's Tail after finishing a combo.", VPR.JobID)]
+    [CustomComboInfo("Serpent's Maw (AoE) Feature", "Replace Steel Maw and Reaving Maw with Serpent's Tail after finishing a combo.", VPR.JobID)]
     ViperSteelTailAoEFeature = 4102,
 
     [SecretCustomCombo]
@@ -1277,11 +1283,11 @@ public enum CustomComboPreset
     ViperFuryAndIreFeature = 4108,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Dread Fangs to Dreadwinder", "Replaces Dread Fangs to Dreadwinder when there are stacks present and not currently in a combo.", VPR.JobID)]
+    [CustomComboInfo("Reaving Fangs to Vicewinder", "Replaces Reaving Fangs to Vicewinder when charges are available and you're not currently in a combo.", VPR.JobID)]
     ViperDreadfangsDreadwinderFeature = 4109,
 
     [SecretCustomCombo]
-    [CustomComboInfo("Dread Maw to Pit of Dread", "Replaces Dread Maw with Pit of Dread when there are stacks present and not currently in a combo.", VPR.JobID)]
+    [CustomComboInfo("Reaving Maw to Vicepit", "Replaces Reaving Maw with Vicepit when charges are available and not you're currently in a combo.", VPR.JobID)]
     ViperPitOfDreadFeature = 4110,
 
     [ConflictingCombos(ViperMergeTwinsSerpentFeature)]
@@ -1315,10 +1321,10 @@ public enum CustomComboPreset
     //[CustomComboInfo("PvP Combo Start Hindsting Strike", "With no buffs, end first combo with Hindsting Strike.", VPR.JobID)]
     //ViperPvPMainComboStartHindstingFeature = 4116,
 
-    [SecretCustomCombo]
-    [ConflictingCombos(ViperSteelTailAoEFeature)]
-    [CustomComboInfo("Viper PvP Style AoE Combo", "Condenses the main combo to a single button, like PvP.\nThe combo can only detect debuffs on the current target.\nStarts with Jagged Maw by default, configurable below.", VPR.JobID)]
-    ViperPvPMainComboAoEFeature = 4117,
+    // [SecretCustomCombo]
+    // [ConflictingCombos(ViperSteelTailAoEFeature)]
+    // [CustomComboInfo("Viper PvP Style AoE Combo", "Condenses the main combo to a single button, like PvP.\nThe combo can only detect debuffs on the current target.\nStarts with Jagged Maw by default, configurable below.", VPR.JobID)]
+    // ViperPvPMainComboAoEFeature = 4117,
 
     //[SecretCustomCombo]
     //[ParentCombo(ViperPvPMainComboAoEFeature)]

--- a/XIVComboExpanded/IconReplacer.cs
+++ b/XIVComboExpanded/IconReplacer.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Reflection;
 
 using Dalamud.Hooking;
-using Dalamud.Logging;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using XIVComboExpandedPlugin.Combos;
 
 namespace XIVComboExpandedPlugin;
@@ -15,6 +15,7 @@ namespace XIVComboExpandedPlugin;
 /// </summary>
 internal sealed partial class IconReplacer : IDisposable
 {
+    private readonly unsafe ActionManager* clientStructActionManager;
     private readonly List<CustomCombo> customCombos;
     private readonly Hook<IsIconReplaceableDelegate> isIconReplaceableHook;
     private readonly Hook<GetIconDelegate> getIconHook;
@@ -24,8 +25,10 @@ internal sealed partial class IconReplacer : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="IconReplacer"/> class.
     /// </summary>
-    public IconReplacer(IGameInteropProvider gameInteropProvider)
+    public unsafe IconReplacer(IGameInteropProvider gameInteropProvider)
     {
+        this.clientStructActionManager = ActionManager.Instance();
+
         this.customCombos = Assembly.GetAssembly(typeof(CustomCombo))!.GetTypes()
             .Where(t => !t.IsAbstract && IsDescendant(t, typeof(CustomCombo)))
             .Select(t => Activator.CreateInstance(t))
@@ -91,6 +94,17 @@ internal sealed partial class IconReplacer : IDisposable
             Service.PluginLog.Error(ex, "Don't crash the game");
             return this.OriginalHook(actionID);
         }
+    }
+
+    /// <summary>
+    /// Gets bool determining if action is greyed out or not.
+    /// </summary>
+    /// <param name="actionID">Action ID.</param>
+    /// <param name="targetID">Target ID.</param>
+    /// <returns>A bool value of whether the action can be used or not.</returns>
+    internal unsafe bool CanUseAction(uint actionID, uint targetID = 0xE000_0000)
+    {
+        return clientStructActionManager->GetActionStatus(ActionType.Action, actionID, targetID, false, true) == 0;
     }
 
     private ulong IsIconReplaceableDetour(uint actionID) => 1;


### PR DESCRIPTION
- Rewrote Viper file to use one class per action/action-pair, rather than than per combo, to remove unpredictable behavior when multiple combos impact the same actions.
- Updated names and descriptions of several Viper combos.
- Integrated `CanUseAction`, thanks to @vitharr137 and @Grammernatzi, which simplifies the Vice combos.

Depends on (and largely overwrites) #366, which this PR could conceivably replace, if you prefer.

I've tested all of the current Viper combos (ie. all but the commented-out PvP ones) locally and they're all working as expected.