### PR TITLE
[BUGFIX] Dragoon Combos

### DIFF
--- a/XIVComboExpanded/Combos/DRG.cs
+++ b/XIVComboExpanded/Combos/DRG.cs
@@ -15,16 +15,14 @@ internal static class DRG
         Disembowel = 87,
         FullThrust = 84,
         ChaosThrust = 88,
-        HeavensThrust = 25771,
-        ChaoticSpring = 25772,
         WheelingThrust = 3556,
         FangAndClaw = 3554,
+        HeavensThrust = 25771,
+        ChaoticSpring = 25772,
         RaidenThrust = 16479,
-        BarrageThrust = 36954,
-        ExplosiveThrust = 36955,
+        LanceBarrage = 36954,
+        SpiralBlow = 36955,
         Drakesbane = 36952,
-        BarrageThrust2 = 36954,
-        ExplosiveThrust2 = 36955,
         // AoE
         DoomSpike = 86,
         SonicThrust = 7397,
@@ -56,6 +54,7 @@ internal static class DRG
             EnhancedWheelingThrust = 803,
             DiveReady = 1243,
             DraconianFire = 1863,
+            PowerSurge = 2720,
             Dragonsflight = 3845,
             StarcrossReady = 3846;
     }
@@ -63,7 +62,8 @@ internal static class DRG
     public static class Debuffs
     {
         public const ushort
-            Placeholder = 0;
+            ChaosThrust = 118,
+            ChaoticSpring = 2719;
     }
 
     public static class Levels
@@ -138,61 +138,110 @@ internal class DragoonSingleTargetThrust : CustomCombo
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        if (IsEnabled(CustomComboPreset.DragoonChaosThrustCombo) || IsEnabled(CustomComboPreset.DragoonFullThrustCombo))
+        if (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring ||
+            actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)
         {
-            if (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring || actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)
+            if (IsEnabled(CustomComboPreset.DragoonFullChaosWyrmwindFeature))
             {
-                if (level >= DRG.Levels.Drakesbane && (lastComboMove == DRG.WheelingThrust || lastComboMove == DRG.FangAndClaw))
-                    return DRG.Drakesbane;
-
-                if (comboTime > 0)
-                {
-                    if (((actionID == DRG.FullThrust || actionID == DRG.HeavensThrust) && IsEnabled(CustomComboPreset.DragoonFullThrustCombo))
-                        || (IsEnabled(CustomComboPreset.DragoonDoubleChaosComboOption) && (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring)))
-                    {
-                        if ((lastComboMove == DRG.FullThrust || lastComboMove == DRG.HeavensThrust) && level >= DRG.Levels.FangAndClaw)
-                            // Claw
-                            return OriginalHook(DRG.FangAndClaw);
-
-                        if ((lastComboMove == DRG.VorpalThrust || lastComboMove == DRG.BarrageThrust) && level >= DRG.Levels.FullThrust)
-                            // Heavens' Thrust
-                            return OriginalHook(DRG.FullThrust);
-                    }
-
-                    if (((actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring) && IsEnabled(CustomComboPreset.DragoonChaosThrustCombo))
-                             || (IsEnabled(CustomComboPreset.DragoonDoubleFullThrustComboOption) && (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)))
-                    {
-                        if ((lastComboMove == DRG.ChaosThrust || lastComboMove == DRG.ChaoticSpring) && level >= DRG.Levels.WheelingThrust)
-                            // Wheeling
-                            return OriginalHook(DRG.WheelingThrust);
-
-                        if ((lastComboMove == DRG.Disembowel || lastComboMove == DRG.ExplosiveThrust) && level >= DRG.Levels.ChaosThrust)
-                            // ChaoticSpring
-                            return OriginalHook(DRG.ChaosThrust);
-                    }
-
-                    if ((actionID == DRG.FullThrust || actionID == DRG.HeavensThrust) && IsEnabled(CustomComboPreset.DragoonFullThrustCombo))
-                    {
-                        if ((lastComboMove == DRG.TrueThrust || lastComboMove == DRG.RaidenThrust) && level >= DRG.Levels.VorpalThrust)
-                            return OriginalHook(DRG.VorpalThrust);
-                    }
-
-                    if ((actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring) && IsEnabled(CustomComboPreset.DragoonChaosThrustCombo))
-                    {
-                        if ((lastComboMove == DRG.TrueThrust || lastComboMove == DRG.RaidenThrust) && level >= DRG.Levels.Disembowel)
-                            return OriginalHook(DRG.Disembowel);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.DragoonFullThrustComboOption) && (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust))
-                        return OriginalHook(DRG.VorpalThrust);
-
-                    if (IsEnabled(CustomComboPreset.DragoonChaosThrustComboOption) && (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring))
-                        return OriginalHook(DRG.Disembowel);
-                }
-
-                if ((IsEnabled(CustomComboPreset.DragoonFullThrustCombo) && actionID == DRG.FullThrust || actionID == DRG.HeavensThrust) || (IsEnabled(CustomComboPreset.DragoonChaosThrustCombo) && actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring))
-                    return OriginalHook(DRG.TrueThrust);
+                var gauge = GetJobGauge<DRGGauge>();
+                if (gauge.FirstmindsFocusCount == 2)
+                    return DRG.WyrmwindThrust;
             }
+
+            if ((IsEnabled(CustomComboPreset.DragoonChaosThrustCombo) ||
+                IsEnabled(CustomComboPreset.DragoonFullThrustCombo) ||
+                IsEnabled(CustomComboPreset.DragoonAllInOneCombo)) &&
+                level >= DRG.Levels.Drakesbane &&
+                (lastComboMove == DRG.WheelingThrust ||  lastComboMove == DRG.FangAndClaw))
+                return DRG.Drakesbane;
+
+            if ((IsEnabled(CustomComboPreset.DragoonFullThrustCombo) &&
+                (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)) ||
+                IsEnabled(CustomComboPreset.DragoonDoubleChaosThrustComboOption) ||
+                IsEnabled(CustomComboPreset.DragoonAllInOneCombo))
+            {
+                if ((lastComboMove == DRG.FullThrust || lastComboMove == DRG.HeavensThrust) &&
+                    level >= DRG.Levels.FangAndClaw)
+                    // Claw
+                    return OriginalHook(DRG.FangAndClaw);
+
+                if ((lastComboMove == DRG.VorpalThrust || lastComboMove == DRG.LanceBarrage) &&
+                    level >= DRG.Levels.FullThrust)
+                    // Heavens' Thrust
+                    return OriginalHook(DRG.FullThrust);
+            }
+
+            if ((IsEnabled(CustomComboPreset.DragoonChaosThrustCombo) &&
+                (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring)) ||
+                IsEnabled(CustomComboPreset.DragoonDoubleFullThrustComboOption) ||
+                IsEnabled(CustomComboPreset.DragoonAllInOneCombo))
+            {
+                if ((lastComboMove == DRG.ChaosThrust || lastComboMove == DRG.ChaoticSpring) &&
+                    level >= DRG.Levels.WheelingThrust)
+                    // Wheeling
+                    return OriginalHook(DRG.WheelingThrust);
+
+                if ((lastComboMove == DRG.Disembowel || lastComboMove == DRG.SpiralBlow) &&
+                    level >= DRG.Levels.ChaosThrust)
+                    // ChaoticSpring
+                    return OriginalHook(DRG.ChaosThrust);
+            }
+
+            if ((lastComboMove == DRG.TrueThrust || lastComboMove == DRG.RaidenThrust) &&
+                level >= DRG.Levels.Disembowel)
+            {
+                if (IsEnabled(CustomComboPreset.DragoonChaosThrustCombo) &&
+                    (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring))
+                    return OriginalHook(DRG.Disembowel);
+
+                if (IsEnabled(CustomComboPreset.DragoonAllInOneCombo))
+                {
+                    var powersurge = FindEffect(DRG.Buffs.PowerSurge);
+                    var chaosthrust = FindTargetEffect(DRG.Debuffs.ChaosThrust);
+                    var chaoticspring = FindTargetEffect(DRG.Debuffs.ChaoticSpring);
+                    var buffThreshold = 15.0; // 12.5s until next Disembowel opportunity
+                    var dotThreshold = 9.0; // DoT naturally lasts 6 seconds less than Disembowel
+                    if (level < DRG.Levels.Drakesbane)
+                    {
+                        buffThreshold -= 2.5;
+                        dotThreshold -= 2.5;
+                    }
+                    if (level < DRG.Levels.FangAndClaw)
+                    {
+                        buffThreshold -= 2.5;
+                        dotThreshold -= 2.5;
+                    }
+
+                    if (!((chaosthrust?.RemainingTime > dotThreshold ||
+                        chaoticspring?.RemainingTime > dotThreshold) &&
+                        powersurge?.RemainingTime > buffThreshold))
+                        return OriginalHook(DRG.Disembowel);
+
+                    return OriginalHook(DRG.VorpalThrust);
+                }
+            }
+
+            if ((lastComboMove == DRG.TrueThrust || lastComboMove == DRG.RaidenThrust) &&
+                level >= DRG.Levels.VorpalThrust)
+            {
+                if ((IsEnabled(CustomComboPreset.DragoonFullThrustCombo) &&
+                    (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust)) ||
+                    IsEnabled(CustomComboPreset.DragoonAllInOneCombo))
+                    return OriginalHook(DRG.VorpalThrust);
+            }
+
+            if (IsEnabled(CustomComboPreset.DragoonFullThrustCombo) &&
+                !IsEnabled(CustomComboPreset.DragoonFullThrustComboOption) &&
+                (actionID == DRG.FullThrust || actionID == DRG.HeavensThrust))
+                return OriginalHook(DRG.TrueThrust);
+
+            if (IsEnabled(CustomComboPreset.DragoonChaosThrustCombo) &&
+                !IsEnabled(CustomComboPreset.DragoonChaosThrustComboOption) &&
+                (actionID == DRG.ChaosThrust || actionID == DRG.ChaoticSpring))
+                return OriginalHook(DRG.TrueThrust);
+
+            if (IsEnabled(CustomComboPreset.DragoonAllInOneCombo))
+                return OriginalHook(DRG.TrueThrust);
         }
 
         return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1,3 +1,4 @@
+using Dalamud.Utility;
 using XIVComboExpandedPlugin.Attributes;
 using XIVComboExpandedPlugin.Combos;
 
@@ -426,6 +427,14 @@ public enum CustomComboPreset
     // ====================================================================================
     #region DRAGOON
 
+    // [IconsCombo([DRG.RaidenThrust, DRG.LanceBarrage, DRG.SpiralBlow, DRG.HeavensThrust, DRG.ChaoticSpring, DRG.FangAndClaw, DRG.WheelingThrust, DRG.Drakesbane, UTL.Cycle])]
+    // [SectionCombo("Single Target")]
+    // [AccessibilityCustomCombo]
+    [ConflictingCombos(DragoonFullThrustCombo, DragoonChaosThrustCombo)]
+    [CustomComboInfo("All-In-One Combo", "Replace Full Thrust and Chaos Thrust with the entire 10-part combo chain, auto-selecting the Chaos Thrust combo as needed to refresh Power Surge or the bleed\n\nNOTE: This can cause you to miss positionals.", DRG.JobID)]
+    DragoonAllInOneCombo = 2216,
+
+    [ConflictingCombos(DragoonAllInOneCombo)]
     [CustomComboInfo("Full Thrust Combo", "Replace Full Thrust with its combo chain.", DRG.JobID)]
     DragoonFullThrustCombo = 2204,
 
@@ -434,9 +443,10 @@ public enum CustomComboPreset
     DragoonFullThrustComboOption = 2210,
 
     [ParentCombo(DragoonFullThrustCombo)]
-    [CustomComboInfo("Double Chaos Thrust Option", "Replicates the Full Thrust combo while not in the Chaotic Thrust combo.", DRG.JobID)]
-    DragoonDoubleFullThrustComboOption = 2215,
+    [CustomComboInfo("Double Chaos Thrust Option", "After using Disembowel, replicates the remainder of the Chaos Thrust combo on Full Thrust, starting at Chaos Thrust.  Combined with the Double Full Thrust Option, this allows you to select which combo to use at the 2nd combo step, but the remainder of both combos will be on both buttons", DRG.JobID)]
+    DragoonDoubleChaosThrustComboOption = 2215,
 
+    [ConflictingCombos(DragoonAllInOneCombo)]
     [CustomComboInfo("Chaos Thrust Combo", "Replace Chaos Thrust with its combo chain.", DRG.JobID)]
     DragoonChaosThrustCombo = 2203,
 
@@ -445,8 +455,14 @@ public enum CustomComboPreset
     DragoonChaosThrustComboOption = 2209,
 
     [ParentCombo(DragoonChaosThrustCombo)]
-    [CustomComboInfo("Double Full Thrust Option", "Replicates the Chaotic Thrust combo while not in the Full Thrust combo.", DRG.JobID)]
-    DragoonDoubleChaosComboOption = 2214,
+    [CustomComboInfo("Double Full Thrust Option", "After using Vorpal Thrust, replicates the remainder of the Full Thrust combo on Chaos Thrust, starting at Full Thrust.  Combined with the Double Choas Thrust Option, this allows you to select which combo to use at the 2nd combo step, but the remainder of both combos will be on both buttons", DRG.JobID)]
+    DragoonDoubleFullThrustComboOption = 2214,
+
+    // [IconsCombo([DRG.HeavensThrust, DRG.ChaoticSpring, UTL.ArrowLeft, DRG.WyrmwindThrust, UTL.Idea])]
+    // [SectionCombo("Single Target")]
+    // [AccessibilityCustomCombo]
+    [CustomComboInfo("Full Chaos Wyrmwind Feature", "Replace Full Thrust and Chaos Thrust with Wyrmwind Thrust when you have two Firstminds' Focus.", DRG.JobID)]
+    DragoonFullChaosWyrmwindFeature = 2217,
 
     [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain.", DRG.JobID)]
     DragoonCoerthanTormentCombo = 2202,


### PR DESCRIPTION
- Fixed bug in Dragoon Vorpal Thrust Option and Disembowel Option that prevented them from working
- Fixed bug causing both of the main Dragoon combo options to affect both buttons.
- Updated main single-target combo block structure.
- Pulled in Dragoon All-In-One combo from my local files, and included a header pending the Attributes Rework
- Pulled in a single target version of the AoE Wyrmwind Feature, also with a Rework header.
- Reworded the descriptions of the two Double combo features to clarify what they do.  Also swapped the var names to match the combo names.
- Renamed BarrageThrust to LanceBarrage and ExplosiveThrust to SpiralBlow, to match English client naming.
- Removed duplicate BarrageThrust2 and ExplosiveThrust2 definitions.
- Added buff and debuff definitions the new All-In-One logic depends on.

Fixes #380, fixes #344