### PR TITLE
Healers DOT Feature prepull Fix

### DIFF
--- a/XIVComboExpanded/Combos/SCH.cs
+++ b/XIVComboExpanded/Combos/SCH.cs
@@ -260,7 +260,7 @@ internal class ScholarRuin : CustomCombo
     {
         if (actionID == SCH.Ruin || actionID == SCH.Broil || actionID == SCH.Broil2 || actionID == SCH.Broil3 || actionID == SCH.Broil4)
         {
-            if (IsEnabled(CustomComboPreset.ScholarDoTFeature) && TargetIsEnemy())
+            if (IsEnabled(CustomComboPreset.ScholarDoTFeature) && InCombat() && TargetIsEnemy())
             {
                 var bio = FindTargetEffect(SCH.Debuffs.Bio);
                 var bio2 = FindTargetEffect(SCH.Debuffs.Bio2);

--- a/XIVComboExpanded/Combos/SGE.cs
+++ b/XIVComboExpanded/Combos/SGE.cs
@@ -92,10 +92,10 @@ internal class SageDosis : CustomCombo
         {
             if (IsEnabled(CustomComboPreset.SageDosisPsyche))
             {
-                if (level >= SGE.Levels.Psyche && IsCooldownUsable(SGE.Psyche) && HasTarget())
+                if (level >= SGE.Levels.Psyche && IsCooldownUsable(SGE.Psyche) && InCombat() && TargetIsEnemy())
                     return OriginalHook(SGE.Psyche);
             }
-            if (IsEnabled(CustomComboPreset.SageDoTFeature) && TargetIsEnemy())
+            if (IsEnabled(CustomComboPreset.SageDoTFeature) && InCombat() && TargetIsEnemy())
             {
                 var eurkasiandosis = FindTargetEffect(SGE.Debuffs.EukrasianDosis);
                 var eurkasiandosis2 = FindTargetEffect(SGE.Debuffs.EukrasianDosis2);

--- a/XIVComboExpanded/Combos/WHM.cs
+++ b/XIVComboExpanded/Combos/WHM.cs
@@ -203,7 +203,7 @@ internal class WhiteMageGlare4Feature : CustomCombo
     {
         if (actionID == WHM.Stone)
         {
-            if (IsEnabled(CustomComboPreset.WhiteMageDoTFeature) && TargetIsEnemy())
+            if (IsEnabled(CustomComboPreset.WhiteMageDoTFeature) && InCombat() && TargetIsEnemy())
             {
                 var aero = FindTargetEffect(WHM.Debuffs.Aero);
                 var aero2 = FindTargetEffect(WHM.Debuffs.Aero2);


### PR DESCRIPTION
Healers dot combos were making it impossible to prepull with default gcd because it had hasTarget instead of InCombat, changed so you'll be able to prepull with your gcd and only then the combos will be active.