### PR TITLE
[FEATURE] SAM - Option to not replace Iaijutsu with a single Sen active

### DIFF
--- a/XIVComboExpanded/Combos/SAM.cs
+++ b/XIVComboExpanded/Combos/SAM.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 
@@ -227,10 +228,19 @@ internal class SamuraiIaijutsu : CustomCombo
                     return SAM.Shoha;
             }
 
-            if (IsEnabled(CustomComboPreset.SamuraiIaijutsuTsubameGaeshiFeature))
+            if (IsEnabled(CustomComboPreset.SamuraiIaijutsuTsubameGaeshiFeature) && level >= SAM.Levels.TsubameGaeshi)
             {
+                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuSingleSenNoReplaceTsubameFeature))
+                {
+                    var hasSingleSen = new[] { gauge.HasSetsu, gauge.HasGetsu, gauge.HasKa }.Count(b => b) == 1;
+                    if (hasSingleSen)
+                    {
+                        return actionID;
+                    }
+                }
+
                 var original = OriginalHook(SAM.TsubameGaeshi);
-                if (level >= SAM.Levels.TsubameGaeshi && CanUseAction(original))
+                if (CanUseAction(original))
                     return original;
             }
         }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1942,6 +1942,12 @@ public enum CustomComboPreset
     [CustomComboInfo("Iaijutsu to Tsubame-gaeshi", "Replace Iaijutsu with Tsubame-gaeshi when it is usable", SAM.JobID)]
     SamuraiIaijutsuTsubameGaeshiFeature = 3409,
 
+    [SectionCombo("Iaijutsu")]
+    [SecretCustomCombo]
+    [CustomComboInfo("Iaijutsu to Tsubame-gaeshi Single Sen", "Don't replace Iaijutsu with a single Sen active", SAM.JobID)]
+    [ParentCombo(SamuraiIaijutsuTsubameGaeshiFeature)]
+    SamuraiIaijutsuSingleSenNoReplaceTsubameFeature = 3422,
+
     [IconsCombo([SAM.Iaijutsu, UTL.ArrowLeft, SAM.Shoha, UTL.Blank, SAM.Shoha, UTL.Checkmark])]
     [SectionCombo("Iaijutsu")]
     [ExpandedCustomCombo]


### PR DESCRIPTION
I used the API documentation [here](https://dalamud.dev/api/Dalamud.Game.ClientState.JobGauge.Types/Classes/SAMGauge#hassetsu) for the job gauge info.

This sub-option is specifically to handle fast SAM's odd burst window, which looks like this:

![image](https://github.com/user-attachments/assets/ffe4c6b6-8b50-414c-be5a-edfc8d945cac)

We want to delay the Tsubame (6th icon) until after applying Higanbana (4th and 5th) icons. With the change in this request, we will not replace Iaijutsu with Tsubame while there is a single Sen active, allowing us to re-apply Higanbana first. Without this option, the existing behavior is that we are forced to use Tsubame first to clear the Tsubame-ready buff, which delays re-applying Higanbana.

Note, C# XOR is only functional for two operands, so I'm using a fairly cheap Linq query. I can expand this out to the actual logic operators if need be, but they are far less readable.