### PR TITLE
Add a few extras to single target for GNB

### DIFF
--- a/XIVComboExpanded/Combos/GNB.cs
+++ b/XIVComboExpanded/Combos/GNB.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using System;
 
@@ -165,10 +166,32 @@ internal class GunbreakerBurstStrikeFatedCircle : CustomCombo
     {
         if (actionID == GNB.BurstStrike)
         {
+            if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeDangerZone))
+            {
+                if (level >= GNB.Levels.DangerZone && IsCooldownUsable(GNB.DangerZone))
+                    return OriginalHook(GNB.DangerZone);
+            }
+
             if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeCont))
             {
                 if (level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
                     return GNB.Hypervelocity;
+            }
+
+            if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeGnashingFang))
+            {
+                if (level >= GNB.Levels.GnashingFang)
+                {
+                    var gauge = GetJobGauge<GNBGauge>();
+                    if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangCont) &&
+                        (HasEffect(GNB.Buffs.ReadyToRip) ||
+                         HasEffect(GNB.Buffs.ReadyToTear) ||
+                         HasEffect(GNB.Buffs.ReadyToGouge)))
+                        return OriginalHook(GNB.Continuation);
+                    if ((IsCooldownUsable(GNB.GnashingFang) && gauge.Ammo > 0) || !IsOriginal(GNB.GnashingFang))
+                        return OriginalHook(GNB.GnashingFang);
+
+                }
             }
         }
 
@@ -251,7 +274,6 @@ internal class GunbreakerDemonSlaughter : CustomCombo
                     {
                         return GNB.FatedBrand;
                     }
-
 
                     if (level >= GNB.Levels.FatedCircle && gauge.Ammo == maxAmmo)
                         return GNB.FatedCircle;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -833,6 +833,18 @@ public enum CustomComboPreset
     [CustomComboInfo("Gnashing Fang Continuation", "Replace Gnashing Fang with Continuation moves when appropriate.", GNB.JobID)]
     GunbreakerGnashingFangCont = 3702,
 
+    [SectionCombo("Single Target")]
+    [IconsCombo([GNB.BurstStrike, UTL.ArrowLeft, GNB.GnashingFang])]
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Burst Strike into Gnashing Fang", "Replace Burst Strike with Gnashing Fang if available.", GNB.JobID)]
+    GunbreakerBurstStrikeGnashingFang = 3724,
+
+    [SectionCombo("Single Target")]
+    [IconsCombo([GNB.BurstStrike, UTL.ArrowLeft, GNB.DangerZone])]
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Burst Strike into Danger Zone", "Replace Burst Strike with Danger Zone if available.", GNB.JobID)]
+    GunbreakerBurstStrikeDangerZone = 3725,
+
     [SectionCombo("Area of Effect")]
     [IconsCombo([GNB.DemonSlaughter, UTL.ArrowLeft, GNB.DemonSlice])]
     [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID)]


### PR DESCRIPTION
Putting Gnashing Fang and Danger Zone on the same ST spender button felt intuitive for me, marked as accessibility