### PR TITLE
[Fix] Reduce surging tempest refresh timer to 15s

### DIFF
--- a/XIVComboExpanded/Combos/WAR.cs
+++ b/XIVComboExpanded/Combos/WAR.cs
@@ -114,7 +114,7 @@ internal class WarriorStormsPathCombo : CustomCombo
                         return WAR.StormsEye;
 
                     if (!IsEnabled(CustomComboPreset.WarriorOptimizeSurgingTempestFeature) &&
-                        surgingTempest.RemainingTime < 30)
+                        surgingTempest.RemainingTime < 15)
                         return WAR.StormsEye;
 
                     // Medicated + Opener

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2364,7 +2364,7 @@ public enum CustomComboPreset
     [SectionCombo("Single Target")]
     [IconsCombo([WAR.StormsPath, UTL.ArrowLeft, WAR.StormsEye, UTL.Blank, WAR.Buffs.SurgingTempest, UTL.Idea])]
     [AccessibilityCustomCombo]
-    [CustomComboInfo("Automatic Surging Tempest", "Replace Storm's Path with Storm's Eye whenever Surging Tempest is below 30 seconds.", WAR.JobID)]
+    [CustomComboInfo("Automatic Surging Tempest", "Replace Storm's Path with Storm's Eye whenever Surging Tempest is below 15 seconds.", WAR.JobID)]
     WarriorAutoSurgingTempestFeature = 2113,
 
     [SectionCombo("Single Target")]


### PR DESCRIPTION
Refreshing surging tempest at 30 seconds will make your gauge go 40 instead of 50 hence will make you lose a fell cleave inside the pot in the M4S transition, changed it to refresh to 15s to avoid that, it should also help in other fights.