### PR TITLE
[FEATURE] Adjust Star Prism combo

### DIFF
--- a/XIVComboExpanded/Combos/PCT.cs
+++ b/XIVComboExpanded/Combos/PCT.cs
@@ -7,64 +7,69 @@ internal static class PCT
     public const byte JobID = 42;
 
     public const uint
-        FireRed = 34650,
-        AeroGreen = 34651,
-        WaterBlue = 34652,
-        BlizzardCyan = 34653,
-        EarthYellow = 34654,
-        ThunderMagenta = 34655,
-        ExtraFireRed = 34656,
-        ExtraAeroGreen = 34657,
-        ExtraWaterBlue = 34658,
-        ExtraBlizzardCyan = 34659,
-        ExtraEarthYellow = 34660,
-        ExtraThunderMagenta = 34661,
-        HolyInWhite = 34662,
+        FireRedST = 34650,
+        AeroGreenST = 34651,
+        WaterBlueST = 34652,
+        BlizzardCyanST = 34653,
+        EarthYellowST = 34654,
+        ThunderMagentaST = 34655,
+
+        FireRedAoE = 34656,
+        AeroGreenAoE = 34657,
+        WaterBlueAoE = 34658,
+        BlizzardCyanAoE = 34659,
+        EarthYellowAoE = 34660,
+        ThunderMagentaAoE = 34661,
+
+        HolyWhite = 34662,
         CometBlack = 34663,
+        RainbowDrip = 34688,
+
+        CreatureMotif = 34689,
         PomMotif = 34664,
         WingMotif = 34665,
         ClawMotif = 34666,
         MawMotif = 34667,
-        HammerMotif = 34668,
-        StarrySkyMotif = 34669,
+        LivingMuse = 35347,
         PomMuse = 34670,
         WingedMuse = 34671,
         ClawedMuse = 34672,
         FangedMuse = 34673,
-        StrikingMuse = 34674,
-        StarryMuse = 34675,
         MogOftheAges = 34676,
         Retribution = 34677,
+
+        WeaponMotif = 34690,
+        HammerMotif = 34668,
+        SteelMuse = 35348,
+        StrikingMuse = 34674,
         HammerStamp = 34678,
         HammerBrush = 34679,
         PolishingHammer = 34680,
-        StarPrism1 = 34681,
-        StarPrism2 = 34682,
+
+        LandscapeMotif = 34691,
+        StarrySkyMotif = 34669,
+        ScenicMuse = 35349,
+        StarryMuse = 34675,
+        StarPrism = 34681,
+
         SubstractivePalette = 34683,
         Smudge = 34684,
         TemperaCoat = 34685,
-        TemperaGrassa = 34686,
-        RainbowDrip = 34688,
-        CreatureMotif = 34689,
-        WeaponMotif = 34690,
-        LandscapeMotif = 34691,
-        CreatureMotifDrawn = 35347,
-        WeaponMotifDrawn = 35348,
-        LandscapeMotifDrawn = 35349;
+        TemperaGrassa = 34686;
 
     public static class Buffs
     {
         public const ushort
             SubstractivePalette = 3674,
-            Chroma2Ready = 3675,
-            Chroma3Ready = 3676,
+            Aetherhues1 = 3675,
+            Aetherhues2 = 3676,
             RainbowReady = 3679,
             HammerReady = 3680,
             StarPrismReady = 3681,
-            Installation = 3688,
-            ArtisticInstallation = 3689,
-            SubstractivePaletteReady = 3690,
-            InvertedColors = 3691;
+            Hyperfantasia = 3688,
+            Inspiration = 3689,
+            SubstractiveReady = 3690,
+            MonochromeTones = 3691;
     }
 
     public static class Debuffs
@@ -81,15 +86,15 @@ internal static class PCT
             TemperaCoat = 10,
             WaterBlue = 15,
             Smudge = 20,
-            ExtraFireRed = 25,
+            FireRedAoE = 25,
             CreatureMotif = 30,
             PomMotif = 30,
             WingMotif = 30,
             PomMuse = 30,
             WingedMuse = 30,
             MogOftheAges = 30,
-            ExtraAeroGreen = 35,
-            ExtraWaterBlue = 45,
+            AeroGreenAoE = 35,
+            WaterBlueAoE = 45,
             HammerMotif = 50,
             HammerStamp = 50,
             WeaponMotif = 50,
@@ -103,7 +108,7 @@ internal static class PCT
             ExtraThunderMagenta = 60,
             StarrySkyMotif = 70,
             LandscapeMotif = 70,
-            MiracleWhite = 80,
+            HolyWhite = 80,
             HammerBrush = 86,
             PolishingHammer = 86,
             TemperaGrassa = 88,
@@ -115,8 +120,7 @@ internal static class PCT
             FangedMuse = 96,
             StarryMuse = 70,
             Retribution = 96,
-            StarPrism1 = 100,
-            StarPrism2 = 100;
+            StarPrism = 100;
     }
 
     internal class PictomancerSTCombo : CustomCombo
@@ -127,18 +131,18 @@ internal static class PCT
         {
             var gauge = GetJobGauge<PCTGauge>();
 
-            if ((actionID == PCT.FireRed || actionID == PCT.BlizzardCyan) && IsEnabled(CustomComboPreset.PictomancerRainbowStarter) && !InCombat() && level >= PCT.Levels.RainbowDrip)
+            if ((actionID == PCT.FireRedST || actionID == PCT.BlizzardCyanST) && IsEnabled(CustomComboPreset.PictomancerRainbowStarter) && !InCombat() && level >= PCT.Levels.RainbowDrip)
             {
                 return PCT.RainbowDrip;
             }
 
-            if (actionID == PCT.FireRed || actionID == PCT.BlizzardCyan)
+            if (actionID == PCT.FireRedST || actionID == PCT.BlizzardCyanST)
             {
                 if (IsEnabled(CustomComboPreset.PictomancerStarPrismAutoCombo))
                 {
                     if (HasEffect(PCT.Buffs.StarPrismReady))
                     {
-                        return PCT.StarPrism1;
+                        return PCT.StarPrism;
                     }
                 }
 
@@ -161,10 +165,10 @@ internal static class PCT
                 if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAutoCombo) && !HasEffect(PCT.Buffs.SubstractivePalette) && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
                 {
                     if (IsEnabled(CustomComboPreset.PictomancerSubtractiveEarlyAutoCombo)
-                        && (gauge.PalleteGauge >= 50 || HasEffect(PCT.Buffs.SubstractivePaletteReady)))
+                        && (gauge.PalleteGauge >= 50 || HasEffect(PCT.Buffs.SubstractiveReady)))
                         return PCT.SubstractivePalette;
 
-                    if (HasEffect(PCT.Buffs.SubstractivePaletteReady) || (HasEffect(PCT.Buffs.Chroma3Ready) && (gauge.PalleteGauge == 100)))
+                    if (HasEffect(PCT.Buffs.SubstractiveReady) || (HasEffect(PCT.Buffs.Aetherhues2) && (gauge.PalleteGauge == 100)))
                         return PCT.SubstractivePalette;
                 }
 
@@ -172,9 +176,9 @@ internal static class PCT
                 {
                     if (gauge.Paint == 5)
                     {
-                        if (HasEffect(PCT.Buffs.InvertedColors))
+                        if (HasEffect(PCT.Buffs.MonochromeTones))
                             return PCT.CometBlack;
-                        return PCT.HolyInWhite;
+                        return PCT.HolyWhite;
                     }
                 }
 
@@ -182,16 +186,16 @@ internal static class PCT
                 {
                     if (!HasEffect(PCT.Buffs.SubstractivePalette))
                     {
-                        if (HasEffect(PCT.Buffs.Chroma2Ready))
+                        if (HasEffect(PCT.Buffs.Aetherhues1))
                         {
-                            return PCT.AeroGreen;
+                            return PCT.AeroGreenST;
                         }
-                        else if (HasEffect(PCT.Buffs.Chroma3Ready))
+                        else if (HasEffect(PCT.Buffs.Aetherhues2))
                         {
-                            return PCT.WaterBlue;
+                            return PCT.WaterBlueST;
                         }
 
-                        return PCT.FireRed;
+                        return PCT.FireRedST;
                     }
                 }
             }
@@ -208,20 +212,20 @@ internal static class PCT
         {
             var gauge = GetJobGauge<PCTGauge>();
 
-            if ((actionID == PCT.ExtraFireRed || actionID == PCT.ExtraBlizzardCyan) && IsEnabled(CustomComboPreset.PictomancerRainbowStarter) && !InCombat())
+            if ((actionID == PCT.FireRedAoE || actionID == PCT.BlizzardCyanAoE) && IsEnabled(CustomComboPreset.PictomancerRainbowStarter) && !InCombat())
             {
                 return PCT.RainbowDrip;
             }
 
-            if (actionID == PCT.ExtraBlizzardCyan)
+            if (actionID == PCT.BlizzardCyanAoE)
             {
                 if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAutoCombo) && !HasEffect(PCT.Buffs.SubstractivePalette) && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
                 {
                     if (IsEnabled(CustomComboPreset.PictomancerSubtractiveEarlyAutoCombo)
-                        && (gauge.PalleteGauge >= 50 || HasEffect(PCT.Buffs.SubstractivePaletteReady)))
+                        && (gauge.PalleteGauge >= 50 || HasEffect(PCT.Buffs.SubstractiveReady)))
                         return PCT.SubstractivePalette;
 
-                    if (HasEffect(PCT.Buffs.Chroma3Ready) && (gauge.PalleteGauge == 100))
+                    if (HasEffect(PCT.Buffs.Aetherhues2) && (gauge.PalleteGauge == 100))
                         return PCT.SubstractivePalette;
                 }
 
@@ -229,18 +233,18 @@ internal static class PCT
                 {
                     if (!HasEffect(PCT.Buffs.SubstractivePalette))
                     {
-                        if (actionID == PCT.ExtraBlizzardCyan)
+                        if (actionID == PCT.BlizzardCyanAoE)
                         {
-                            if (HasEffect(PCT.Buffs.Chroma2Ready) && level >= PCT.Levels.ExtraAeroGreen)
+                            if (HasEffect(PCT.Buffs.Aetherhues1) && level >= PCT.Levels.AeroGreenAoE)
                             {
-                                return PCT.ExtraAeroGreen;
+                                return PCT.AeroGreenAoE;
                             }
-                            else if (HasEffect(PCT.Buffs.Chroma3Ready) && level >= PCT.Levels.ExtraWaterBlue)
+                            else if (HasEffect(PCT.Buffs.Aetherhues2) && level >= PCT.Levels.WaterBlueAoE)
                             {
-                                return PCT.ExtraWaterBlue;
+                                return PCT.WaterBlueAoE;
                             }
 
-                            return OriginalHook(PCT.ExtraFireRed);
+                            return OriginalHook(PCT.FireRedAoE);
                         }
                     }
                 }
@@ -257,9 +261,9 @@ internal static class PCT
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gauge = GetJobGauge<PCTGauge>();
-            if (actionID == PCT.WaterBlue || actionID == PCT.ExtraWaterBlue)
+            if (actionID == PCT.WaterBlueST || actionID == PCT.WaterBlueAoE)
             {
-                if (HasEffect(PCT.Buffs.Chroma3Ready) && !HasEffect(PCT.Buffs.SubstractivePalette) && gauge.PalleteGauge == 100 && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
+                if (HasEffect(PCT.Buffs.Aetherhues2) && !HasEffect(PCT.Buffs.SubstractivePalette) && gauge.PalleteGauge == 100 && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
                 {
                     return PCT.SubstractivePalette;
                 }
@@ -275,14 +279,14 @@ internal static class PCT
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == PCT.HolyInWhite)
+            if (actionID == PCT.HolyWhite)
             {
                 if (IsEnabled(CustomComboPreset.PictomancerRainbowHolyCombo) && HasEffect(PCT.Buffs.RainbowReady))
                 {
                     return PCT.RainbowDrip;
                 }
 
-                if (HasEffect(PCT.Buffs.InvertedColors))
+                if (HasEffect(PCT.Buffs.MonochromeTones))
                     return PCT.CometBlack;
             }
 
@@ -313,8 +317,8 @@ internal static class PCT
                 {
                     if (actionID == PCT.CreatureMotif)
                     {
-                        if (OriginalHook(PCT.CreatureMotifDrawn) != PCT.CreatureMotifDrawn)
-                            return OriginalHook(PCT.CreatureMotifDrawn);
+                        if (OriginalHook(PCT.LivingMuse) != PCT.LivingMuse)
+                            return OriginalHook(PCT.LivingMuse);
                     }
                 }
             }
@@ -364,17 +368,29 @@ internal static class PCT
             {
                 if (IsEnabled(CustomComboPreset.PictomancerLandscapeMotifCombo))
                 {
-                    if (gauge.LandscapeMotifDrawn)
-                        return PCT.StarryMuse;
-                }
+                    if (IsEnabled(CustomComboPreset.PictomancerLandscapePrismCombo) &&
+                        HasEffect(PCT.Buffs.StarPrismReady))
+                        return OriginalHook(PCT.StarPrism);
 
-                if (IsEnabled(CustomComboPreset.PictomancerLandscapePrismCombo))
-                {
-                    if (HasEffect(PCT.Buffs.StarPrismReady))
-                    {
-                        return OriginalHook(PCT.StarPrism1);
-                    }
+                    if (gauge.LandscapeMotifDrawn)
+                        return OriginalHook(PCT.ScenicMuse);
                 }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class PictomancerStarryMuseCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerLandscapePrismCombo;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == PCT.ScenicMuse)
+            {
+                if (HasEffect(PCT.Buffs.StarPrismReady))
+                    return OriginalHook(PCT.StarPrism);
             }
 
             return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1461,30 +1461,30 @@ public enum CustomComboPreset
     // ====================================================================================
     #region PICTOMANCER
 
-    [IconsCombo([PCT.BlizzardCyan, UTL.ArrowLeft, PCT.FireRed, UTL.Blank, PCT.SubstractivePalette, UTL.Cross])]
+    [IconsCombo([PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.FireRedST, UTL.Blank, PCT.SubstractivePalette, UTL.Cross])]
     [SectionCombo("Substractive")]
     [CustomComboInfo("Subtractive Single-Target Combo", "Replace Blizzard in Cyan and its combo chain with Fire in Red and its combo chain when Subtractive Palette is not active.", PCT.JobID)]
     PictomancerSubtractiveSTCombo = 4201,
 
-    [IconsCombo([PCT.ExtraBlizzardCyan, UTL.ArrowLeft, PCT.ExtraFireRed, UTL.Blank, PCT.SubstractivePalette, UTL.Cross])]
+    [IconsCombo([PCT.BlizzardCyanAoE, UTL.ArrowLeft, PCT.FireRedAoE, UTL.Blank, PCT.SubstractivePalette, UTL.Cross])]
     [SectionCombo("Substractive")]
     [CustomComboInfo("Subtractive AoE Combo", "Replace Blizzard II in Cyan and its combo chain with Fire II in Red and its combo chain when Subtractive Palette is not active.", PCT.JobID)]
     PictomancerSubtractiveAoECombo = 4202,
 
-    [IconsCombo([PCT.FireRed, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, UTL.Blank, UTL.Danger])]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, UTL.Blank, UTL.Danger])]
     [SectionCombo("Substractive")]
     [ExpandedCustomCombo]
     [CustomComboInfo("Don't overcap Subtractive", "Replace Fire in Red and Fire II in Red, and their combo chains, with Subtractive Palette if the next cast in the chain would overcap the Palette Gauge.", PCT.JobID)]
     PictomancerSubtractiveAutoCombo = 4205,
 
-    [IconsCombo([PCT.FireRed, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, PCT.Buffs.SubstractivePalette, UTL.Checkmark])]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, PCT.Buffs.SubstractivePalette, UTL.Checkmark])]
     [SectionCombo("Substractive")]
     [AccessibilityCustomCombo]
     [ParentCombo(CustomComboPreset.PictomancerSubtractiveAutoCombo)]
     [CustomComboInfo("Subtractive Early Autocast", "Do it as soon as you reach 50 Palette gauge or you are under the effect of Substractive Palette Ready instead.", PCT.JobID)]
     PictomancerSubtractiveEarlyAutoCombo = 4221,
 
-    [IconsCombo([PCT.CreatureMotif, UTL.ArrowLeft, PCT.PomMuse, PCT.WingedMuse, PCT.ClawedMuse, PCT.FangedMuse, UTL.Blank, PCT.CreatureMotifDrawn, UTL.Checkmark])]
+    [IconsCombo([PCT.CreatureMotif, UTL.ArrowLeft, PCT.LivingMuse, UTL.Blank, PCT.PomMuse, PCT.WingedMuse, PCT.ClawedMuse, PCT.FangedMuse, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
     [CustomComboInfo("Creature Muse/Motif Combo", "Replace Creature Motifs with Creature Muses when the Creature Canvas is painted.", PCT.JobID)]
     PictomancerCreatureMotifCombo = 4206,
@@ -1495,13 +1495,13 @@ public enum CustomComboPreset
     [CustomComboInfo("Creature Muse/Mog of the Ages Combo", "Also replace Creature Motifs with Mog of the Ages and Retribution of the Madeen when they are usable.", PCT.JobID)]
     PictomancerCreatureMogCombo = 4207,
 
-    [IconsCombo([PCT.FireRed, PCT.ExtraFireRed, UTL.ArrowLeft, PCT.MogOftheAges, PCT.Retribution, UTL.Blank, PCT.MogOftheAges, PCT.Retribution, UTL.Checkmark])]
+    [IconsCombo([PCT.FireRedST, PCT.FireRedAoE, UTL.ArrowLeft, PCT.MogOftheAges, PCT.Retribution, UTL.Blank, PCT.MogOftheAges, PCT.Retribution, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
     [AccessibilityCustomCombo]
     [CustomComboInfo("Mog of the Ages Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Mog of the Ages and Retribution of the Madeen when they are usable.", PCT.JobID)]
     PictomancerAutoMogCombo = 4220,
 
-    [IconsCombo([PCT.HammerMotif, UTL.ArrowLeft, PCT.StrikingMuse, UTL.Blank, PCT.WeaponMotifDrawn, UTL.Checkmark])]
+    [IconsCombo([PCT.WeaponMotif, UTL.ArrowLeft, PCT.StrikingMuse, UTL.Blank, PCT.HammerMotif, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
     [CustomComboInfo("Weapon Muse/Motif Combo", "Replace Hammer Motif with Striking Muse when the Weapon Canvas is painted.", PCT.JobID)]
     PictomancerWeaponMotifCombo = 4208,
@@ -1511,47 +1511,47 @@ public enum CustomComboPreset
     [CustomComboInfo("Hammer Time", "Replace Hammer Motif with Hammer Brush and its combo chain when they are usable.", PCT.JobID)]
     PictomancerWeaponHammerCombo = 4209,
 
-    [IconsCombo([PCT.LandscapeMotif, UTL.ArrowLeft, PCT.StarryMuse, UTL.Blank, PCT.LandscapeMotifDrawn, UTL.Checkmark])]
+    [IconsCombo([PCT.LandscapeMotif, UTL.ArrowLeft, PCT.ScenicMuse, UTL.Blank, PCT.StarryMuse, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
-    [CustomComboInfo("Landscape Muse/Motif Combo", "Replace Starry Sky Motif with Starry Muse when the Landscape Canvas is painted.", PCT.JobID)]
+    [CustomComboInfo("Starry Muse/Motif Combo", "Replace Starry Sky Motif with Starry Muse when the Landscape Canvas is painted.", PCT.JobID)]
     PictomancerLandscapeMotifCombo = 4210,
 
-    [IconsCombo([PCT.StarryMuse, UTL.ArrowLeft, PCT.StarPrism1, UTL.Blank, PCT.Buffs.StarPrismReady, UTL.Checkmark])]
+    [IconsCombo([PCT.StarryMuse, UTL.ArrowLeft, PCT.StarPrism, UTL.Blank, PCT.Buffs.StarPrismReady, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
-    [CustomComboInfo("Landscape Muse/Star Prism Combo", "Replace Starry Muse with Star Prism when it is usable.", PCT.JobID)]
+    [CustomComboInfo("Starry Muse/Star Prism Combo", "Replace Starry Muse with Star Prism when it is usable.  Also replaces Starry Sky Motif if the Starry Muse/Motif Combo is selected.", PCT.JobID)]
     PictomancerLandscapePrismCombo = 4211,
 
-    [IconsCombo([PCT.FireRed, UTL.ArrowLeft, PCT.StarryMuse, UTL.Blank, PCT.Buffs.StarPrismReady, UTL.Checkmark])]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.StarryMuse, UTL.Blank, PCT.Buffs.StarPrismReady, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
     [AccessibilityCustomCombo]
     [CustomComboInfo("Star Prism Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Star Prism when you have Star Prism Ready.", PCT.JobID)]
     PictomancerStarPrismAutoCombo = 4214,
 
-    [IconsCombo([PCT.HolyInWhite, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, PCT.CometBlack, UTL.Checkmark])]
+    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, PCT.CometBlack, UTL.Checkmark])]
     [SectionCombo("Holy Comet")]
     [CustomComboInfo("Holy Comet Combo", "Replace Holy in White with Comet in Black when usable.", PCT.JobID)]
     PictomancerHolyCometCombo = 4203,
 
-    [IconsCombo([PCT.HolyInWhite, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
+    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
     [SectionCombo("Holy Comet")]
     [ExpandedCustomCombo]
     [ParentCombo(PictomancerHolyCometCombo)]
     [CustomComboInfo("Rainbow Holy Combo", "Replace Holy in White with Rainbow Drip when under the effect of Rainbow Drip Ready (has priority over Comet in Black).", PCT.JobID)]
     PictomancerRainbowHolyCombo = 4215,
 
-    [IconsCombo([PCT.FireRed, PCT.BlizzardCyan, UTL.ArrowLeft, PCT.HolyInWhite, UTL.Blank, PCT.HolyInWhite, UTL.Danger])]
+    [IconsCombo([PCT.FireRedST, PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.HolyWhite, UTL.Blank, PCT.HolyWhite, UTL.Danger])]
     [SectionCombo("Holy Comet")]
     [AccessibilityCustomCombo]
     [CustomComboInfo("Holy Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Holy or Comet if the next cast would overcap the Paint Gauge.", PCT.JobID)]
     PictomancerHolyAutoCombo = 4204,
 
-    [IconsCombo([PCT.FireRed, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
     [SectionCombo("Rainbow Drip")]
     [AccessibilityCustomCombo]
     [CustomComboInfo("Rainbow Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Rainbow Drip when you have Rainbow Drip Ready.", PCT.JobID)]
     PictomancerRainbowAutoCombo = 4213,
 
-    [IconsCombo([PCT.FireRed, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.RainbowDrip, UTL.OutOfBattle])]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.RainbowDrip, UTL.OutOfBattle])]
     [SectionCombo("Rainbow Drip")]
     [SecretCustomCombo]
     [CustomComboInfo("Rainbow Drip Starter", "Replace Fire in Red & Fire in Red II with Rainbow Drip when out of combat.", PCT.JobID)]


### PR DESCRIPTION
- Updated Starry Muse + Star Prism combo to no longer assume the Starry Muse + Motif combo is also taken.
  - If the Muse + Prism combo is enabled and the Muse + Motif combo is not, then Prism will replace Scenic/Starry Muse, but not Landscape/Starry Sky Motif.
  - If both are enabled, Prism will act as it currently does, replacing both the Muse and the Motif when available.
- Prioritized Prism over Starry Muse.  I don't THINK it's possible to have both available at once, but just in case.
- Renamed a number of the PCT globals to match their English client names, and sectioned the PCT action IDs by category/association.
- Updated the icon pattern and combo name for the Landscape Muse/Motif and Muse/Prism combos.

Fixes #461 