### PR TITLE
[QUICKFIX] Level checks greater-than-or-equal-to

### DIFF
--- a/XIVComboExpanded/Combos/BLM.cs
+++ b/XIVComboExpanded/Combos/BLM.cs
@@ -130,7 +130,7 @@ internal class BlackFireBlizzard4 : CustomCombo
                                     return BLM.Despair;
                                 if (HasEffect(BLM.Buffs.Firestarter)) // rare case usually caused by rotation error or clipping
                                     return BLM.Fire3;
-                                if (level > BLM.Levels.Paradox && gauge.IsParadoxActive) // typical use case
+                                if (level >= BLM.Levels.Paradox && gauge.IsParadoxActive) // typical use case
                                     return BLM.Paradox;
                                 if (level >= BLM.Levels.Despair && LocalPlayer?.CurrentMp >= 800) // suboptimal despair usage, but still better than Blizzard3
                                     return BLM.Despair;
@@ -165,7 +165,7 @@ internal class BlackFireBlizzard4 : CustomCombo
                     if (IsEnabled(CustomComboPreset.BlackEnochianUmbralIceFeature) && gauge.UmbralIceStacks < 3)
                     {
                         if (level >= BLM.Levels.Blizzard3 && (HasEffect(BLM.Buffs.Swiftcast) || HasEffect(BLM.Buffs.Triplecast)))
-                            return BLM.Blizzard3; 
+                            return BLM.Blizzard3;
                         return OriginalHook(BLM.Blizzard);
                     }
 

--- a/XIVComboExpanded/Combos/MNK.cs
+++ b/XIVComboExpanded/Combos/MNK.cs
@@ -146,7 +146,7 @@ internal class MonkRaptorCombo : CustomCombo
                     return OriginalHook(MNK.MasterfulBlitz);
             }
 
-            if (gauge.RaptorFury == 0 && level > MNK.Levels.TwinSnakes)
+            if (gauge.RaptorFury == 0 && level >= MNK.Levels.TwinSnakes)
                 return MNK.TwinSnakes;
         }
 

--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -183,7 +183,7 @@ internal class ReaperSlice : CustomCombo
                     return RPR.Perfectio;
             }
 
-            if (level > RPR.Levels.BloodStalk && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
+            if (level >= RPR.Levels.BloodStalk && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
             {
                 // Blood Stalk if we're over 90 gauge, or if we're over 50 and the overcap-only feature isn't enabled,
                 // or if the auto-Soul Slice feature is enabled and our next action would otherwise be Soul Slice.
@@ -200,7 +200,7 @@ internal class ReaperSlice : CustomCombo
                 }
             }
 
-            if (level > RPR.Levels.SoulSlice && IsEnabled(CustomComboPreset.ReaperAutoSoulSliceFeature))
+            if (level >= RPR.Levels.SoulSlice && IsEnabled(CustomComboPreset.ReaperAutoSoulSliceFeature))
             {
                 if (IsCooldownUsable(RPR.SoulSlice) && gauge.Soul <= 50)
                     return RPR.SoulSlice;
@@ -281,7 +281,7 @@ internal class ReaperScythe : CustomCombo
                     return RPR.HarvestMoon;
             }
 
-            if (level > RPR.Levels.GrimSwathe && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
+            if (level >= RPR.Levels.GrimSwathe && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
             {
                 // Blood Stalk if we're over 90 gauge, or if we're over 50 and the overcap-only feature isn't enabled,
                 // or if the auto-Soul Slice feature is enabled and our next action would otherwise be Soul Slice.
@@ -298,7 +298,7 @@ internal class ReaperScythe : CustomCombo
                 }
             }
 
-            if (level > RPR.Levels.SoulScythe && IsEnabled(CustomComboPreset.ReaperAutoSoulSliceFeature))
+            if (level >= RPR.Levels.SoulScythe && IsEnabled(CustomComboPreset.ReaperAutoSoulSliceFeature))
             {
                 if (IsCooldownUsable(RPR.SoulScythe) && gauge.Soul <= 50)
                     return RPR.SoulScythe;
@@ -461,7 +461,7 @@ internal class ReaperSoulSlice : CustomCombo
                     return OriginalHook(RPR.Gallows);
                 }
 
-                if (level > RPR.Levels.BloodStalk && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
+                if (level >= RPR.Levels.BloodStalk && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
                 {
                     if (gauge.Soul >= 50 && (gauge.Soul > 50 ||
                         !IsEnabled(CustomComboPreset.ReaperReaperAutoBloodStalkOvercapFeature)))
@@ -520,7 +520,7 @@ internal class ReaperSoulScythe : CustomCombo
                 if (HasEffect(RPR.Buffs.SoulReaver) || HasEffect(RPR.Buffs.Executioner))
                     return OriginalHook(RPR.Guillotine);
 
-                if (level > RPR.Levels.GrimSwathe && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
+                if (level >= RPR.Levels.GrimSwathe && IsEnabled(CustomComboPreset.ReaperAutoSoulReaverFeature))
                 {
                     if (gauge.Soul >= 50 && (gauge.Soul > 50 ||
                         !IsEnabled(CustomComboPreset.ReaperReaperAutoBloodStalkOvercapFeature)))


### PR DESCRIPTION
- Fixed RPR level checks for Automatic Soul Reaper to use `>=` instead of `>`.
- For good measure, searched for every other usage of `>` on level and replaced with `>=`.

Fixes #469 