### PR TITLE
[SAM] Auto-AoE

### DIFF
--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2077,15 +2077,30 @@ public enum CustomComboPreset
     [CustomComboInfo("Kasha Combo Option", "Start the Kasha combo chain with Shifu instead of Hakaze.", SAM.JobID)]
     SamuraiKashaOption = 3417,
 
-    [IconsCombo([SAM.Mangetsu, UTL.ArrowLeft, SAM.Fuga])]
+    [IconsCombo([SAM.Mangetsu, SAM.Oka, UTL.ArrowLeft, SAM.Fuga, SAM.Fuko])]
     [SectionCombo("Area of Effect")]
-    [CustomComboInfo("Mangetsu Combo", "Replace Mangetsu with its combo chain.", SAM.JobID)]
-    SamuraiMangetsuCombo = 3404,
+    [CustomComboInfo("Oka/Mangetsu Combo", "Replace Oka and Mangetsu with their combo chain.", SAM.JobID)]
+    SamuraiAoECombo = 3404,
 
     [IconsCombo([SAM.Oka, UTL.ArrowLeft, SAM.Fuga])]
     [SectionCombo("Area of Effect")]
-    [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain.", SAM.JobID)]
-    SamuraiOkaCombo = 3405,
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Auto-AoE", "Replace Oka and Mengutsu with whichever one you don't have the Sen for yet.  If you have both or neither Sen, neither one will be replaced.", SAM.JobID)]
+    SamuraiAutoAoEFeature = 3423,
+
+    [IconsCombo([SAM.Oka, UTL.ArrowLeft, SAM.Fuga])]
+    [SectionCombo("Area of Effect")]
+    [AccessibilityCustomCombo]
+    [ParentCombo(SamuraiAutoAoEFeature)]
+    [CustomComboInfo("Auto-AoE Buff Upkeep", "Also replace Oka and Mangutsu with each other in order to upkeep the buffs they apply, provided you either have neither of the two Sen, or already have both.  When you have neither or both of the Sen, both Oka and Mangetsu will be replaced with whichever one grants the buff that currently has the shortest duration on you (or is currently absent).  If both buffs are absent, neither ability will be replaced", SAM.JobID)]
+    SamuraiAutoAoEBuffFeature = 3424,
+
+    [IconsCombo([SAM.Oka, UTL.ArrowLeft, SAM.Fuga])]
+    [SectionCombo("Area of Effect")]
+    [AccessibilityCustomCombo]
+    [ParentCombo(SamuraiAutoAoEFeature)]
+    [CustomComboInfo("Auto-AoE Goken Finale", "Also replace Oka and Mangutsu with Iaijutsu (Tenka Goken) when you have both Sen.  Obeys the 'Iaijutsu to Tsubame-gaeshi' feature as well: if that feature is enabled, this will also include the follow-up Kaeshi: Goken when available.", SAM.JobID)]
+    SamuraiAutoAoEFinaleFeature = 3425,
 
     [IconsCombo([SAM.Iaijutsu, UTL.ArrowLeft, SAM.TsubameGaeshi])]
     [SectionCombo("Iaijutsu")]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2082,24 +2082,24 @@ public enum CustomComboPreset
     [CustomComboInfo("Oka/Mangetsu Combo", "Replace Oka and Mangetsu with their combo chain.", SAM.JobID)]
     SamuraiAoECombo = 3404,
 
-    [IconsCombo([SAM.Oka, UTL.ArrowLeft, SAM.Fuga])]
+    [IconsCombo([SAM.Oka, SAM.Mangetsu, UTL.Blank, UTL.Blank2, UTL.Idea])]
     [SectionCombo("Area of Effect")]
     [AccessibilityCustomCombo]
-    [CustomComboInfo("Auto-AoE", "Replace Oka and Mengutsu with whichever one you don't have the Sen for yet.  If you have both or neither Sen, neither one will be replaced.", SAM.JobID)]
+    [CustomComboInfo("Auto-AoE", "Replace Oka and Mangetsu with whichever one you don't have the Sen for yet.  If you have both or neither Sen, neither one will be replaced.", SAM.JobID)]
     SamuraiAutoAoEFeature = 3423,
 
-    [IconsCombo([SAM.Oka, UTL.ArrowLeft, SAM.Fuga])]
+    [IconsCombo([SAM.Oka, SAM.Mangetsu, UTL.Blank, SAM.Buffs.Fugetsu, SAM.Buffs.Fuka])]
     [SectionCombo("Area of Effect")]
     [AccessibilityCustomCombo]
     [ParentCombo(SamuraiAutoAoEFeature)]
-    [CustomComboInfo("Auto-AoE Buff Upkeep", "Also replace Oka and Mangutsu with each other in order to upkeep the buffs they apply, provided you either have neither of the two Sen, or already have both.  When you have neither or both of the Sen, both Oka and Mangetsu will be replaced with whichever one grants the buff that currently has the shortest duration on you (or is currently absent).  If both buffs are absent, neither ability will be replaced", SAM.JobID)]
+    [CustomComboInfo("Auto-AoE Buff Upkeep", "Also replace Oka and Mangetsu with each other in order to upkeep the buffs they apply, provided you either have neither of the two Sen, or already have both.  When you have neither or both of the Sen, both Oka and Mangetsu will be replaced with whichever one grants the buff that currently has the shortest duration on you (or is currently absent).  If both buffs are absent, neither ability will be replaced", SAM.JobID)]
     SamuraiAutoAoEBuffFeature = 3424,
 
-    [IconsCombo([SAM.Oka, UTL.ArrowLeft, SAM.Fuga])]
+    [IconsCombo([SAM.Oka, SAM.Mangetsu, UTL.ArrowLeft, SAM.TenkaGoken, SAM.TendoGoken])]
     [SectionCombo("Area of Effect")]
     [AccessibilityCustomCombo]
     [ParentCombo(SamuraiAutoAoEFeature)]
-    [CustomComboInfo("Auto-AoE Goken Finale", "Also replace Oka and Mangutsu with Iaijutsu (Tenka Goken) when you have both Sen.  Obeys the 'Iaijutsu to Tsubame-gaeshi' feature as well: if that feature is enabled, this will also include the follow-up Kaeshi: Goken when available.", SAM.JobID)]
+    [CustomComboInfo("Auto-AoE Goken Finale", "Also replace Oka and Mangetsu with Iaijutsu (Tenka Goken) when you have both Sen.  Obeys the 'Iaijutsu to Tsubame-gaeshi' feature as well: if that feature is enabled, this will also include the follow-up Kaeshi: Goken when available.", SAM.JobID)]
     SamuraiAutoAoEFinaleFeature = 3425,
 
     [IconsCombo([SAM.Iaijutsu, UTL.ArrowLeft, SAM.TsubameGaeshi])]


### PR DESCRIPTION
- Merged Mangetsu and Oka combos and implementation code.
- Added new combo that auto-selected Oka or Mangetsu based on which Sen is missing
- Added sub-combo to also auto-select them by remaining buff timer.
- Added sub-combo to also include Tenka/Tendo Goken, and Tsubame if selected, when both Sen are present.
- Added a number of missing levels and action IDs for SAM.
- Renamed the Jinpu and Shifu buff constants to match their in-game name since Endwalker.

Fixed #472 