### PR TITLE
[SAM] Add Hissatsu: Guren features

### DIFF
--- a/XIVComboExpanded/Combos/SAM.cs
+++ b/XIVComboExpanded/Combos/SAM.cs
@@ -348,6 +348,33 @@ internal class SamuraiKyuten : CustomCombo
     }
 }
 
+internal class SamuraiGuren : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SamAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == SAM.HissatsuGuren)
+        {
+            var gauge = GetJobGauge<SAMGauge>();
+
+            if (IsEnabled(CustomComboPreset.SamuraiGurenZanshinFeature))
+            {
+                if (level >= SAM.Levels.Zanshin && HasEffect(SAM.Buffs.ZanshinReady))
+                    return SAM.Zanshin;
+            }
+
+            if (IsEnabled(CustomComboPreset.SamuraiGurenShohaFeature))
+            {
+                if (level >= SAM.Levels.Shoha && gauge.MeditationStacks >= 3)
+                    return SAM.Shoha;
+            }
+        }
+
+        return actionID;
+    }
+}
+
 internal class SamuraiIkishoten : CustomCombo
 {
     protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SamuraiIkishotenNamikiriFeature;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2149,11 +2149,23 @@ public enum CustomComboPreset
     [CustomComboInfo("Kyuten to Shoha", "Replace Hissatsu: Kyuten with Shoha when Meditation is full.", SAM.JobID)]
     SamuraiKyutenShohaFeature = 3412,
 
-    [IconsCombo([SAM.HissatsuShinten, UTL.ArrowLeft, SAM.HissatsuGuren, UTL.Blank, SAM.HissatsuGuren, UTL.Checkmark])]
+    [IconsCombo([SAM.HissatsuKyuten, UTL.ArrowLeft, SAM.HissatsuGuren, UTL.Blank, SAM.HissatsuGuren, UTL.Checkmark])]
     [SectionCombo("Kyuten")]
     [ExpandedCustomCombo]
     [CustomComboInfo("Kyuten to Guren", "Replace Hissatsu: Kyuten with Guren when available.", SAM.JobID)]
     SamuraiKyutenGurenFeature = 3415,
+
+    [IconsCombo([SAM.HissatsuGuren, UTL.ArrowLeft, SAM.Zanshin, UTL.Blank, SAM.Zanshin, UTL.Checkmark])]
+    [SectionCombo("Guren")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Guren to Zanshin", "Replace Hissatsu: Guren with Zanshin when available.", SAM.JobID)]
+    SamuraiGurenZanshinFeature = 3426,
+
+    [IconsCombo([SAM.HissatsuGuren, UTL.ArrowLeft, SAM.Shoha, UTL.Blank, SAM.Shoha, UTL.Checkmark])]
+    [SectionCombo("Guren")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Guren to Shoha", "Replace Hissatsu: Guren with Shoha when Meditation is full.", SAM.JobID)]
+    SamuraiGurenShohaFeature = 3427,
 
     [IconsCombo([SAM.Ikishoten, UTL.ArrowLeft, SAM.OgiNamikiri, SAM.KaeshiNamikiri, UTL.Blank, SAM.OgiNamikiri, SAM.KaeshiNamikiri, UTL.Checkmark])]
     [SectionCombo("Ikishoten")]


### PR DESCRIPTION
Creates a new combo section "Guren".
Adds a feature in the Guren section to replace Hissatsu: Guren with Zanshin when it is available.
Adds a feature in the Guren section to replace Hissatsu: Guren with Shoha when Meditation is full.
Uses very similar code to that found in the Kyuten features.
Tested using v2.0.1.2 as a base version on a local drive, seems to work as intended.

Edited the SamuraiKyutenGurenFeature in CustomComboPreset.cs to fix a typo in the icons (it displayed HissatsuShinten when it should have displayed HissatsuKyuten).

I didn't edit anything in SAM.cs lines 180-186, 197-198, or 225-227.  I am not sure why it's flagging those lines as changed.  

Addresses #450 