### PR TITLE
[FEATURE] [SMN] Primal Favor feature

### DIFF
--- a/XIVComboExpanded/Combos/SMN.cs
+++ b/XIVComboExpanded/Combos/SMN.cs
@@ -64,7 +64,8 @@ internal static class SMN
             GarudasFavor = 2725,
             TitansFavor = 2853,
             RubysGlimmer = 3873,
-            LuxSolarisReady = 3874;
+            LuxSolarisReady = 3874,
+            CrimsonStrikeReady = 4403;
     }
 
     public static class Debuffs
@@ -319,6 +320,34 @@ internal class SummonerLuxSolarisFeature : CustomCombo
         {
             if (HasEffect(SMN.Buffs.LuxSolarisReady))
                 return SMN.LuxSolaris;
+        }
+
+        return actionID;
+    }
+}
+
+internal class SummonerPrimalSummons : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerPrimalFavorFeature;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == SMN.SummonRuby || actionID == SMN.SummonIfrit || actionID == SMN.SummonIfrit2)
+        {
+            if (HasEffect(SMN.Buffs.IfritsFavor) || HasEffect(SMN.Buffs.CrimsonStrikeReady))
+                return OriginalHook(SMN.AstralFlow);
+        }
+
+        if (actionID == SMN.SummonEmerald || actionID == SMN.SummonGaruda || actionID == SMN.SummonGaruda2)
+        {
+            if (HasEffect(SMN.Buffs.GarudasFavor))
+                return OriginalHook(SMN.AstralFlow);
+        }
+
+        if (actionID == SMN.SummonTopaz || actionID == SMN.SummonTitan || actionID == SMN.SummonTitan2)
+        {
+            if (HasEffect(SMN.Buffs.TitansFavor))
+                return OriginalHook(SMN.AstralFlow);
         }
 
         return actionID;

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -2330,9 +2330,15 @@ public enum CustomComboPreset
 
     [IconsCombo([SMN.SummonBahamut, SMN.SummonPhoenix, SMN.SummonSolarBahamut, UTL.ArrowLeft, SMN.SearingLight, UTL.Blank, SMN.Buffs.RubysGlimmer, UTL.Checkmark, UTL.Plus, SMN.SummonBahamut, SMN.SummonPhoenix, SMN.SummonSolarBahamut, UTL.Clock])]
     [SectionCombo("Summons features")]
-    [SecretCustomCombo]
-    [CustomComboInfo("Searing Demi Flash Feature", "Replace Summon Bahamut, Summon Phoenix and Summon Solar Bahamut with Searing Light when Ruby's Glimmer is available, Searing Light is off cooldown, Summon Demi is on cooldown, and you are in combat.", SMN.JobID)]
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Searing Demi Flash Feature", "Replace Summon Bahamut, Summon Phoenix and Summon Solar Bahamut with Searing Light when Ruby's Glimmer is available or Searing Light is off cooldown, and Summon Demi is on cooldown and you are in combat.", SMN.JobID)]
     SummonerSearingDemiFlashFeature = 2719,
+
+    [IconsCombo([SMN.SummonIfrit, SMN.SummonGaruda, SMN.SummonTitan, UTL.ArrowLeft, SMN.AstralFlow, UTL.Blank, SMN.Buffs.IfritsFavor, SMN.Buffs.GarudasFavor, SMN.Buffs.TitansFavor, UTL.Checkmark])]
+    [SectionCombo("Summons features")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Primal Favor Feature", "Replace Summon Ifrit, Summon Garuda, and Summon Titan with their respective Astral Flow action when their respective Favor buff is active.", SMN.JobID)]
+    SummonerPrimalFavorFeature = 2720,
 
     [IconsCombo([SMN.Gemshine, SMN.PreciousBrilliance, UTL.ArrowLeft, SMN.MountainBuster, UTL.Blank, SMN.Buffs.TitansFavor, UTL.Checkmark])]
     [SectionCombo("Gems features")]


### PR DESCRIPTION
- Implemented new feature that replaces each of the 3 elemental primal summons with their respective Astral Flow action when their Favor buff is active.

Fixes #446