### PR TITLE
[FEATURE] PCT update 7.2

### DIFF
--- a/XIVComboExpanded/Combos/PCT.cs
+++ b/XIVComboExpanded/Combos/PCT.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
+﻿using Dalamud.Game.ClientState.JobGauge.Enums;
+using Dalamud.Game.ClientState.JobGauge.Types;
 
 namespace XIVComboExpandedPlugin.Combos;
 
@@ -66,7 +67,7 @@ internal static class PCT
             RainbowReady = 3679,
             HammerReady = 3680,
             StarPrismReady = 3681,
-            Hyperfantasia = 3688,
+            Hyperphantasia = 3688,
             Inspiration = 3689,
             SubstractiveReady = 3690,
             MonochromeTones = 3691;
@@ -87,318 +88,340 @@ internal static class PCT
             WaterBlue = 15,
             Smudge = 20,
             FireRedAoE = 25,
-            CreatureMotif = 30,
-            PomMotif = 30,
-            WingMotif = 30,
-            PomMuse = 30,
-            WingedMuse = 30,
-            MogOftheAges = 30,
+            MoogleMotifs = 30,
             AeroGreenAoE = 35,
             WaterBlueAoE = 45,
             HammerMotif = 50,
-            HammerStamp = 50,
-            WeaponMotif = 50,
-            StrikingMuse = 50,
             SubstractivePalette = 60,
-            BlizzardCyan = 60,
-            EarthYellow = 60,
-            ThunderMagenta = 60,
-            ExtraBlizzardCyan = 60,
-            ExtraEarthYellow = 60,
-            ExtraThunderMagenta = 60,
             StarrySkyMotif = 70,
-            LandscapeMotif = 70,
             HolyWhite = 80,
-            HammerBrush = 86,
+            HammerExtended = 86,
             PolishingHammer = 86,
             TemperaGrassa = 88,
             CometBlack = 90,
             RainbowDrip = 92,
-            ClawMotif = 96,
-            MawMotif = 96,
-            ClawedMuse = 96,
-            FangedMuse = 96,
-            StarryMuse = 70,
+            MadeenMotifs = 96,
             Retribution = 96,
             StarPrism = 100;
     }
+}
 
-    internal class PictomancerSTCombo : CustomCombo
+internal class PictomancerSTCombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+        var gauge = GetJobGauge<PCTGauge>();
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        if (actionID == PCT.FireRedST || actionID == PCT.BlizzardCyanST)
         {
-            var gauge = GetJobGauge<PCTGauge>();
-
-            if ((actionID == PCT.FireRedST || actionID == PCT.BlizzardCyanST) && IsEnabled(CustomComboPreset.PictomancerRainbowStarter) && !InCombat() && level >= PCT.Levels.RainbowDrip)
+            if (IsEnabled(CustomComboPreset.PictomancerRainbowStarterCombo))
             {
-                return PCT.RainbowDrip;
-            }
-
-            if (actionID == PCT.FireRedST || actionID == PCT.BlizzardCyanST)
-            {
-                if (IsEnabled(CustomComboPreset.PictomancerStarPrismAutoCombo))
-                {
-                    if (HasEffect(PCT.Buffs.StarPrismReady))
-                    {
-                        return PCT.StarPrism;
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerRainbowAutoCombo))
-                {
-                    if (HasEffect(PCT.Buffs.RainbowReady))
-                    {
-                        return PCT.RainbowDrip;
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerAutoMogCombo))
-                {
-                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && GetRemainingCharges(PCT.MogOftheAges) > 0 && CanUseAction(OriginalHook(PCT.MogOftheAges)))
-                    {
-                        return OriginalHook(PCT.MogOftheAges);
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAutoCombo) && !HasEffect(PCT.Buffs.SubstractivePalette) && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
-                {
-                    if (IsEnabled(CustomComboPreset.PictomancerSubtractiveEarlyAutoCombo)
-                        && (gauge.PalleteGauge >= 50 || HasEffect(PCT.Buffs.SubstractiveReady)))
-                        return PCT.SubstractivePalette;
-
-                    if (HasEffect(PCT.Buffs.SubstractiveReady) || (HasEffect(PCT.Buffs.Aetherhues2) && (gauge.PalleteGauge == 100)))
-                        return PCT.SubstractivePalette;
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerHolyAutoCombo))
-                {
-                    if (gauge.Paint == 5)
-                    {
-                        if (HasEffect(PCT.Buffs.MonochromeTones))
-                            return PCT.CometBlack;
-                        return PCT.HolyWhite;
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerSubtractiveSTCombo))
-                {
-                    if (!HasEffect(PCT.Buffs.SubstractivePalette))
-                    {
-                        if (HasEffect(PCT.Buffs.Aetherhues1))
-                        {
-                            return PCT.AeroGreenST;
-                        }
-                        else if (HasEffect(PCT.Buffs.Aetherhues2))
-                        {
-                            return PCT.WaterBlueST;
-                        }
-
-                        return PCT.FireRedST;
-                    }
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class PictomancerAoECombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<PCTGauge>();
-
-            if ((actionID == PCT.FireRedAoE || actionID == PCT.BlizzardCyanAoE) && IsEnabled(CustomComboPreset.PictomancerRainbowStarter) && !InCombat())
-            {
-                return PCT.RainbowDrip;
-            }
-
-            if (actionID == PCT.BlizzardCyanAoE)
-            {
-                if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAutoCombo) && !HasEffect(PCT.Buffs.SubstractivePalette) && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
-                {
-                    if (IsEnabled(CustomComboPreset.PictomancerSubtractiveEarlyAutoCombo)
-                        && (gauge.PalleteGauge >= 50 || HasEffect(PCT.Buffs.SubstractiveReady)))
-                        return PCT.SubstractivePalette;
-
-                    if (HasEffect(PCT.Buffs.Aetherhues2) && (gauge.PalleteGauge == 100))
-                        return PCT.SubstractivePalette;
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAoECombo))
-                {
-                    if (!HasEffect(PCT.Buffs.SubstractivePalette))
-                    {
-                        if (actionID == PCT.BlizzardCyanAoE)
-                        {
-                            if (HasEffect(PCT.Buffs.Aetherhues1) && level >= PCT.Levels.AeroGreenAoE)
-                            {
-                                return PCT.AeroGreenAoE;
-                            }
-                            else if (HasEffect(PCT.Buffs.Aetherhues2) && level >= PCT.Levels.WaterBlueAoE)
-                            {
-                                return PCT.WaterBlueAoE;
-                            }
-
-                            return OriginalHook(PCT.FireRedAoE);
-                        }
-                    }
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class PictomancerSubtractiveAutoCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerSubtractiveAutoCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<PCTGauge>();
-            if (actionID == PCT.WaterBlueST || actionID == PCT.WaterBlueAoE)
-            {
-                if (HasEffect(PCT.Buffs.Aetherhues2) && !HasEffect(PCT.Buffs.SubstractivePalette) && gauge.PalleteGauge == 100 && CanUseAction(OriginalHook(PCT.SubstractivePalette)))
-                {
-                    return PCT.SubstractivePalette;
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class PictomancerHolyCometCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerHolyCometCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == PCT.HolyWhite)
-            {
-                if (IsEnabled(CustomComboPreset.PictomancerRainbowHolyCombo) && HasEffect(PCT.Buffs.RainbowReady))
-                {
+                if (level >= PCT.Levels.RainbowDrip && !InCombat())
                     return PCT.RainbowDrip;
-                }
+            }
 
-                if (IsEnabled(CustomComboPreset.PictomancerHolyHammerCombo) && HasEffect(PCT.Buffs.HammerReady))
+            if (IsEnabled(CustomComboPreset.PictomancerStarPrismAutoCombo))
+            {
+                if (HasEffect(PCT.Buffs.StarPrismReady) &&
+                    (!IsEnabled(CustomComboPreset.PictomancerStarPrismAfterSubtractiveFeature) ||
+                    (!HasEffect(PCT.Buffs.SubstractivePalette) && !HasEffect(PCT.Buffs.SubstractiveReady))))
+                    return PCT.StarPrism;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerRainbowAutoCombo))
+            {
+                if (HasEffect(PCT.Buffs.RainbowReady) &&
+                    (gauge.Paint < 5 || !IsEnabled(CustomComboPreset.PictomancerAutoHolyCombo)))
+                    return PCT.RainbowDrip;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerAutoMogCombo))
+            {
+                if (IsEnabled(CustomComboPreset.PictomancerAutoMogOvercapCombo))
                 {
-                    return OriginalHook(PCT.HammerStamp);
-                }
+                    var moogleNext = (gauge.CreatureFlags & CreatureFlags.Pom) != 0 &&
+                        (gauge.CreatureFlags & CreatureFlags.Wings) == 0;
+                    var madeenNext = (gauge.CreatureFlags & CreatureFlags.Claw) != 0;
 
-                if (HasEffect(PCT.Buffs.MonochromeTones))
+                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && gauge.CreatureMotifDrawn &&
+                        (level < PCT.Levels.MadeenMotifs || moogleNext || madeenNext))
+                        return OriginalHook(PCT.MogOftheAges);
+                }
+                else
+                {
+                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                        IsCooldownUsable(PCT.MogOftheAges))
+                            return OriginalHook(PCT.MogOftheAges);
+                }
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerAutoCometFeature))
+            {
+                if (HasEffect(PCT.Buffs.MonochromeTones) &&
+                    (!IsEnabled(CustomComboPreset.PictomancerCometAfterSubtractive) ||
+                    !HasEffect(PCT.Buffs.SubstractivePalette)) &&
+                    (!IsEnabled(CustomComboPreset.PictomancerCometStarryOnly) ||
+                    HasEffect(PCT.Buffs.Inspiration)))
                     return PCT.CometBlack;
             }
 
-            return actionID;
-        }
-    }
-
-    internal class PictomancerCreatureMotifCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<PCTGauge>();
-
-            if (actionID == PCT.CreatureMotif)
+            if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAutoCombo) &&
+                !HasEffect(PCT.Buffs.SubstractivePalette) && level >= PCT.Levels.SubstractivePalette)
             {
-                if (IsEnabled(CustomComboPreset.PictomancerCreatureMogCombo) && CanUseAction(OriginalHook(PCT.MogOftheAges)))
+                if (HasEffect(PCT.Buffs.SubstractiveReady))
+                    return PCT.SubstractivePalette;
+
+                if (gauge.PalleteGauge >= 50 && !IsEnabled(CustomComboPreset.PictomancerSubtractiveOvercap))
+                    return PCT.SubstractivePalette;
+
+                if (gauge.PalleteGauge > 80 && HasEffect(PCT.Buffs.Aetherhues2))
+                    return PCT.SubstractivePalette;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerAutoHolyCombo))
+            {
+                if (gauge.Paint == 5 && HasEffect(PCT.Buffs.Aetherhues2))
+                    return HasEffect(PCT.Buffs.MonochromeTones) ? PCT.CometBlack : PCT.HolyWhite;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerSubtractiveSTCombo) &&
+                !HasEffect(PCT.Buffs.SubstractivePalette))
+                return OriginalHook(PCT.FireRedST);
+        }
+
+        return actionID;
+    }
+}
+
+internal class PictomancerAoECombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        var gauge = GetJobGauge<PCTGauge>();
+
+        if (actionID == PCT.FireRedAoE || actionID == PCT.BlizzardCyanAoE)
+        {
+            if (IsEnabled(CustomComboPreset.PictomancerRainbowStarterCombo))
+            {
+                if (level >= PCT.Levels.RainbowDrip && !InCombat())
+                    return PCT.RainbowDrip;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerStarPrismAutoCombo))
+            {
+                if (HasEffect(PCT.Buffs.StarPrismReady) &&
+                    (!IsEnabled(CustomComboPreset.PictomancerStarPrismAfterSubtractiveFeature) ||
+                    (!HasEffect(PCT.Buffs.SubstractivePalette) && !HasEffect(PCT.Buffs.SubstractiveReady))))
+                    return PCT.StarPrism;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerRainbowAutoCombo))
+            {
+                if (HasEffect(PCT.Buffs.RainbowReady) &&
+                    (gauge.Paint < 5 || !IsEnabled(CustomComboPreset.PictomancerAutoHolyCombo)))
+                    return PCT.RainbowDrip;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerAutoMogCombo))
+            {
+                if (IsEnabled(CustomComboPreset.PictomancerAutoMogOvercapCombo))
                 {
-                    if (gauge.MooglePortraitReady || gauge.MadeenPortraitReady)
-                    {
-                        if (IsCooldownUsable(PCT.MogOftheAges))
+                    var moogleNext = (gauge.CreatureFlags & CreatureFlags.Pom) != 0 &&
+                        (gauge.CreatureFlags & CreatureFlags.Wings) == 0;
+                    var madeenNext = (gauge.CreatureFlags & CreatureFlags.Claw) != 0;
+
+                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && gauge.CreatureMotifDrawn &&
+                        (level < PCT.Levels.MadeenMotifs || moogleNext || madeenNext))
+                        return OriginalHook(PCT.MogOftheAges);
+                }
+                else
+                {
+                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                        IsCooldownUsable(PCT.MogOftheAges))
                             return OriginalHook(PCT.MogOftheAges);
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.PictomancerCreatureMotifCombo))
-                {
-                    if (actionID == PCT.CreatureMotif)
-                    {
-                        if (OriginalHook(PCT.LivingMuse) != PCT.LivingMuse)
-                            return OriginalHook(PCT.LivingMuse);
-                    }
                 }
             }
 
-            return actionID;
+            if (IsEnabled(CustomComboPreset.PictomancerAutoCometFeature))
+            {
+                if (HasEffect(PCT.Buffs.MonochromeTones) &&
+                    (!IsEnabled(CustomComboPreset.PictomancerCometAfterSubtractive) ||
+                    !HasEffect(PCT.Buffs.SubstractivePalette)) &&
+                    (!IsEnabled(CustomComboPreset.PictomancerCometStarryOnly) ||
+                    HasEffect(PCT.Buffs.Inspiration)))
+                    return PCT.CometBlack;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAutoCombo) &&
+                !HasEffect(PCT.Buffs.SubstractivePalette) && level >= PCT.Levels.SubstractivePalette)
+            {
+                if (HasEffect(PCT.Buffs.SubstractiveReady))
+                    return PCT.SubstractivePalette;
+
+                if (gauge.PalleteGauge >= 50 && !IsEnabled(CustomComboPreset.PictomancerSubtractiveOvercap))
+                    return PCT.SubstractivePalette;
+
+                if (gauge.PalleteGauge > 80 && HasEffect(PCT.Buffs.Aetherhues2))
+                    return PCT.SubstractivePalette;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerAutoHolyCombo))
+            {
+                if (gauge.Paint == 5 && HasEffect(PCT.Buffs.Aetherhues2))
+                    return HasEffect(PCT.Buffs.MonochromeTones) ? PCT.CometBlack : PCT.HolyWhite;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerSubtractiveAoECombo) && !HasEffect(PCT.Buffs.SubstractivePalette))
+                return OriginalHook(PCT.FireRedAoE);
         }
+
+        return actionID;
     }
+}
 
-    internal class PictomancerWeaponMotifCombo : CustomCombo
+internal class PictomancerHolyCometCombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        if (actionID == PCT.HolyWhite)
         {
             var gauge = GetJobGauge<PCTGauge>();
 
-            if (actionID == PCT.WeaponMotif)
-            {
-                if (IsEnabled(CustomComboPreset.PictomancerWeaponMotifCombo))
-                {
-                    if (gauge.WeaponMotifDrawn)
-                        return PCT.StrikingMuse;
-                }
+            if (IsEnabled(CustomComboPreset.PictomancerRainbowStarterHoly) &&
+                level >= PCT.Levels.RainbowDrip && !InCombat())
+                return PCT.RainbowDrip;
 
-                if (IsEnabled(CustomComboPreset.PictomancerWeaponHammerCombo))
+            if (IsEnabled(CustomComboPreset.PictomancerRainbowHolyCombo) && HasEffect(PCT.Buffs.RainbowReady) &&
+                (gauge.Paint < 5 || !IsEnabled(CustomComboPreset.PictomancerAutoHolyCombo)))
+                return PCT.RainbowDrip;
+
+            if (IsEnabled(CustomComboPreset.PictomancerHolyHammerCombo) && HasEffect(PCT.Buffs.HammerReady))
+                return OriginalHook(PCT.HammerStamp);
+
+            if (IsEnabled(CustomComboPreset.PictomancerHolyCometCombo) && HasEffect(PCT.Buffs.MonochromeTones))
+                return PCT.CometBlack;
+        }
+
+        return actionID;
+    }
+}
+
+internal class PictomancerCreatureMotifCombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        var gauge = GetJobGauge<PCTGauge>();
+
+        if (actionID == PCT.CreatureMotif)
+        {
+            if (IsEnabled(CustomComboPreset.PictomancerCreatureMogCombo))
+            {
+                if (IsEnabled(CustomComboPreset.PictomancerCreatureMogOvercapCombo))
                 {
-                    if (HasEffect(PCT.Buffs.HammerReady))
-                    {
-                        return OriginalHook(PCT.HammerStamp);
-                    }
+                    var moogleNext = (gauge.CreatureFlags & CreatureFlags.Pom) != 0 &&
+                        (gauge.CreatureFlags & CreatureFlags.Wings) == 0;
+                    var madeenNext = (gauge.CreatureFlags & CreatureFlags.Claw) != 0;
+
+                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && gauge.CreatureMotifDrawn &&
+                        (level < PCT.Levels.MadeenMotifs || moogleNext || madeenNext))
+                        return OriginalHook(PCT.MogOftheAges);
+                }
+                else
+                {
+                    if ((gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                        IsCooldownUsable(PCT.MogOftheAges))
+                            return OriginalHook(PCT.MogOftheAges);
                 }
             }
 
-            return actionID;
-        }
-    }
-
-    internal class PictomancerLandscapeMotifCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<PCTGauge>();
-
-            if (actionID == PCT.LandscapeMotif)
+            if (IsEnabled(CustomComboPreset.PictomancerCreatureMotifCombo))
             {
-                if (IsEnabled(CustomComboPreset.PictomancerLandscapeMotifCombo))
+                if (actionID == PCT.CreatureMotif)
                 {
-                    if (IsEnabled(CustomComboPreset.PictomancerLandscapePrismCombo) &&
-                        HasEffect(PCT.Buffs.StarPrismReady))
-                        return OriginalHook(PCT.StarPrism);
-
-                    if (gauge.LandscapeMotifDrawn)
-                        return OriginalHook(PCT.ScenicMuse);
+                    if (OriginalHook(PCT.LivingMuse) != PCT.LivingMuse)
+                        return OriginalHook(PCT.LivingMuse);
                 }
             }
-
-            return actionID;
         }
+
+        return actionID;
     }
+}
 
-    internal class PictomancerStarryMuseCombo : CustomCombo
+internal class PictomancerWeaponMotifCombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerLandscapePrismCombo;
+        var gauge = GetJobGauge<PCTGauge>();
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        if (actionID == PCT.WeaponMotif)
         {
-            if (actionID == PCT.ScenicMuse)
+            if (IsEnabled(CustomComboPreset.PictomancerWeaponMotifCombo))
             {
-                if (HasEffect(PCT.Buffs.StarPrismReady))
+                if (gauge.WeaponMotifDrawn)
+                    return PCT.StrikingMuse;
+            }
+
+            if (IsEnabled(CustomComboPreset.PictomancerWeaponHammerCombo))
+            {
+                if (HasEffect(PCT.Buffs.HammerReady))
+                {
+                    return OriginalHook(PCT.HammerStamp);
+                }
+            }
+        }
+
+        return actionID;
+    }
+}
+
+internal class PictomancerLandscapeMotifCombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PctAny;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        var gauge = GetJobGauge<PCTGauge>();
+
+        if (actionID == PCT.LandscapeMotif)
+        {
+            if (IsEnabled(CustomComboPreset.PictomancerLandscapeMotifCombo))
+            {
+                if (IsEnabled(CustomComboPreset.PictomancerLandscapePrismCombo) &&
+                    HasEffect(PCT.Buffs.StarPrismReady))
                     return OriginalHook(PCT.StarPrism);
-            }
 
-            return actionID;
+                if (gauge.LandscapeMotifDrawn)
+                    return OriginalHook(PCT.ScenicMuse);
+            }
         }
+
+        return actionID;
+    }
+}
+
+internal class PictomancerStarryMuseCombo : CustomCombo
+{
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PictomancerLandscapePrismCombo;
+
+    protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+    {
+        if (actionID == PCT.ScenicMuse)
+        {
+            if (HasEffect(PCT.Buffs.StarPrismReady))
+                return OriginalHook(PCT.StarPrism);
+        }
+
+        return actionID;
     }
 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1488,18 +1488,18 @@ public enum CustomComboPreset
     [CustomComboInfo("Subtractive AoE Combo", "Replace Blizzard II in Cyan and its combo chain with Fire II in Red and its combo chain when Subtractive Palette is not active.", PCT.JobID)]
     PictomancerSubtractiveAoECombo = 4202,
 
-    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, UTL.Blank, UTL.Danger])]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, UTL.Blank, UTL.Idea])]
     [SectionCombo("Substractive")]
-    [ExpandedCustomCombo]
-    [CustomComboInfo("Don't overcap Subtractive", "Replace Fire in Red and Fire II in Red, and their combo chains, with Subtractive Palette if the next cast in the chain would overcap the Palette Gauge.", PCT.JobID)]
-    PictomancerSubtractiveAutoCombo = 4205,
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Subtractive Autocast", "Replace Fire in Red and Fire II in Red, and their combo chains, with Subtractive Palette whenever it is usable.", PCT.JobID)]
+    PictomancerSubtractiveAutoCombo = 4221,
 
     [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.SubstractivePalette, UTL.Blank, PCT.Buffs.SubstractivePalette, UTL.Checkmark])]
     [SectionCombo("Substractive")]
-    [AccessibilityCustomCombo]
-    [ParentCombo(CustomComboPreset.PictomancerSubtractiveAutoCombo)]
-    [CustomComboInfo("Subtractive Early Autocast", "Do it as soon as you reach 50 Palette gauge or you are under the effect of Substractive Palette Ready instead.", PCT.JobID)]
-    PictomancerSubtractiveEarlyAutoCombo = 4221,
+    [ParentCombo(PictomancerSubtractiveAutoCombo)]
+    [SecretCustomCombo]
+    [CustomComboInfo("Subtractive Overcap-only", "Only replace with Subtractive Palette if the next cast in the chain would overcap the Palette Gauge or if you have Subtractive Palette Ready from Starry Muse.\n\nNOTE: This is intended to allow more flexibility for when Subtractive Pallet is used, due to the greater demand for stationary casting while it is active.  It is recommended to also have Subtractive Pallet seperately on your hotbars, and to use it manually whenever it makes sense, with this feature simply acting as a guard against Palette waste.", PCT.JobID)]
+    PictomancerSubtractiveOvercap = 4205,
 
     [IconsCombo([PCT.CreatureMotif, UTL.ArrowLeft, PCT.LivingMuse, UTL.Blank, PCT.PomMuse, PCT.WingedMuse, PCT.ClawedMuse, PCT.FangedMuse, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
@@ -1512,11 +1512,24 @@ public enum CustomComboPreset
     [CustomComboInfo("Creature Muse/Mog of the Ages Combo", "Also replace Creature Motifs with Mog of the Ages and Retribution of the Madeen when they are usable.", PCT.JobID)]
     PictomancerCreatureMogCombo = 4207,
 
+    [IconsCombo([PCT.MogOftheAges, PCT.Retribution, UTL.Blank, UTL.Danger])]
+    [SectionCombo("Muses & Motifs")]
+    [ParentCombo(PictomancerCreatureMogCombo)]
+    [CustomComboInfo("Muse/Mog of the Ages only for overcap", "Only replace Creature Motifs with Mog of the Ages and Retribution of the Madeen when your creature canvas is painted and your next Creature Muse cast would overwrite the Moogle or Madeen, rather than as soon as Moogle/Madeen is available, to allow better pooling for burst windows.", PCT.JobID)]
+    PictomancerCreatureMogOvercapCombo = 4223,
+
     [IconsCombo([PCT.FireRedST, PCT.FireRedAoE, UTL.ArrowLeft, PCT.MogOftheAges, PCT.Retribution, UTL.Blank, PCT.MogOftheAges, PCT.Retribution, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
     [AccessibilityCustomCombo]
-    [CustomComboInfo("Mog of the Ages Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Mog of the Ages and Retribution of the Madeen when they are usable.", PCT.JobID)]
+    [CustomComboInfo("Mog of the Ages Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Mog of the Ages and Retribution of the Madeen when they are usable.\n\nNOTE: This has a high chance of clipping your GCD.", PCT.JobID)]
     PictomancerAutoMogCombo = 4220,
+
+    [IconsCombo([PCT.MogOftheAges, PCT.Retribution, UTL.Blank, UTL.Danger])]
+    [SectionCombo("Muses & Motifs")]
+    [AccessibilityCustomCombo]
+    [ParentCombo(PictomancerAutoMogCombo)]
+    [CustomComboInfo("Mog of the Ages Autocast only for overcap", "Only the main spell combo chains with Mog of the Ages and Retribution of the Madeen when your creature canvas is painted and your next Creature Muse cast would overwrite the Moogle or Madeen, rather than as soon as Moogle/Madeen are available, to allow better pooling for burst windows, and reduces the likelihood that the autocast will clip your GCD.", PCT.JobID)]
+    PictomancerAutoMogOvercapCombo = 4229,
 
     [IconsCombo([PCT.WeaponMotif, UTL.ArrowLeft, PCT.StrikingMuse, UTL.Blank, PCT.HammerMotif, UTL.Checkmark])]
     [SectionCombo("Muses & Motifs")]
@@ -1539,47 +1552,78 @@ public enum CustomComboPreset
     PictomancerLandscapePrismCombo = 4211,
 
     [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.StarryMuse, UTL.Blank, PCT.Buffs.StarPrismReady, UTL.Checkmark])]
-    [SectionCombo("Muses & Motifs")]
+    [SectionCombo("Miscellaneous")]
     [AccessibilityCustomCombo]
-    [CustomComboInfo("Star Prism Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Star Prism when you have Star Prism Ready.", PCT.JobID)]
+    [CustomComboInfo("Star Prism Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Star Prism when you have Star Prism Ready.  Has priority over Comet, if enabled along with the Automatic Comet feature.  Also has priority over the Subtractive Pallet combo by default.", PCT.JobID)]
     PictomancerStarPrismAutoCombo = 4214,
 
-    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, PCT.CometBlack, UTL.Checkmark])]
-    [SectionCombo("Holy Comet")]
-    [CustomComboInfo("Holy Comet Combo", "Replace Holy in White with Comet in Black when usable.", PCT.JobID)]
-    PictomancerHolyCometCombo = 4203,
-
-    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
-    [SectionCombo("Holy Comet")]
-    [ExpandedCustomCombo]
-    [ParentCombo(PictomancerHolyCometCombo)]
-    [CustomComboInfo("Rainbow Holy Combo", "Replace Holy in White with Rainbow Drip when under the effect of Rainbow Drip Ready (has priority over Comet in Black and Hammer Stamp, if applicable).", PCT.JobID)]
-    PictomancerRainbowHolyCombo = 4215,
-
-    [IconsCombo([PCT.FireRedST, PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.HolyWhite, UTL.Blank, PCT.HolyWhite, UTL.Danger])]
-    [SectionCombo("Holy Comet")]
-    [AccessibilityCustomCombo]
-    [CustomComboInfo("Holy Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Holy or Comet if the next cast would overcap the Paint Gauge.", PCT.JobID)]
-    PictomancerHolyAutoCombo = 4204,
+    [IconsCombo([PCT.SubstractivePalette, UTL.ArrowUp, PCT.StarPrism])]
+    [SectionCombo("Miscellaneous")]
+    [SecretCustomCombo]
+    [ParentCombo(PictomancerStarPrismAutoCombo)]
+    [CustomComboInfo("Star Prism after Subtractive", "Use Star Prism only if Subtractive Pallet is not currently active.  If enabled with Automatic Comet, Star Prism will be used before Comet in Black.  If enabled with Subtractive Autocast, the free Subtractive Pallet from Starry Muse will be activated and consumed before Star Prism is used.\n\nNOTE: There is a small delay on buffs like Subtractive Spectrum registering.  If you're spamming your main combo spells immediately after using Starry Muse, there's a good chance you'll still cast Star Prism instead of Subtractive first.", PCT.JobID)]
+    PictomancerStarPrismAfterSubtractiveFeature = 4226,
 
     [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
-    [SectionCombo("Rainbow Drip")]
+    [SectionCombo("Miscellaneous")]
     [AccessibilityCustomCombo]
     [CustomComboInfo("Rainbow Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Rainbow Drip when you have Rainbow Drip Ready.", PCT.JobID)]
     PictomancerRainbowAutoCombo = 4213,
 
-    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.RainbowDrip, UTL.OutOfBattle])]
-    [SectionCombo("Rainbow Drip")]
-    [SecretCustomCombo]
-    [CustomComboInfo("Rainbow Drip Starter", "Replace Fire in Red & Fire in Red II with Rainbow Drip when out of combat.", PCT.JobID)]
-    PictomancerRainbowStarter = 4216,
-
-    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.HammerStamp, PCT.HammerBrush, PCT.PolishingHammer, UTL.Blank, PCT.Buffs.HammerReady, UTL.Checkmark])]
-    [SectionCombo("Holy Hammer")]
+    [IconsCombo([PCT.FireRedST, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, UTL.Blank, UTL.OutOfBattle])]
+    [SectionCombo("Miscellaneous")]
     [ExpandedCustomCombo]
-    [ParentCombo(PictomancerHolyCometCombo)]
-    [CustomComboInfo("Holy Hammer Combo", "Replace Holy in White with Hammer Brush and its combo chain when they are usable (has priority over Comet in Black).", PCT.JobID)]
+    [CustomComboInfo("Rainbow Drip Combo Starter", "Replace Fire in Red & Fire in Red II with Rainbow Drip when out of combat.\n\nThis is intended to allow a pre-pull Rainbow Drip cast, but can seriously interfere with initial casts if you are not given a pull timer, as you'll need to enter combo in some other way before you're able to use normal combo casts.  Generally, this is not recommended, even if you're using Rainbow Autocast above.", PCT.JobID)]
+    PictomancerRainbowStarterCombo = 4216,
+
+    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, UTL.Blank, UTL.OutOfBattle])]
+    [SectionCombo("Miscellaneous")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Rainbow Drip Holy Starter", "Replace Holy with Rainbow Drip when out of combat and at 0 Paint charges.\n\nThis is an alternative to the Rainbow Drip Combo Starter that does not interfere with normal combo casts (if not given a pull timer or someone pulls early).  Since it only replaces Holy when at 0 Paint charges, this is more narrowly focused on a prepull cast prior to a boss in a trial or raid, and should interfere less with other circumstances where you're not yet in combat but should not be precasting Rainbow Drip.", PCT.JobID)]
+    PictomancerRainbowStarterHoly = 4227,
+
+    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, PCT.CometBlack, UTL.Checkmark])]
+    [SectionCombo("Holy/Comet")]
+    [CustomComboInfo("Holy Comet Combo", "Replace Holy in White with Comet in Black when usable.", PCT.JobID)]
+    PictomancerHolyCometCombo = 4203,
+
+    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.RainbowDrip, UTL.Blank, PCT.Buffs.RainbowReady, UTL.Checkmark])]
+    [SectionCombo("Holy/Comet")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Rainbow Holy Combo", "Replace Holy in White with Rainbow Drip when under the effect of Rainbow Bright.  Holy/Comet will be used first if Holy Autocast is enabled and you have 5 paint charges.", PCT.JobID)]
+    PictomancerRainbowHolyCombo = 4215,
+
+    [IconsCombo([PCT.HolyWhite, UTL.ArrowLeft, PCT.HammerStamp, UTL.Blank, PCT.Buffs.HammerReady, UTL.Checkmark])]
+    [SectionCombo("Holy/Comet")]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Hammer Holy Combo", "Replace Holy in White with Hammer Brush and its combo chain when they are Hammer Ready is active.  If selected with Holy Comet Combo or Rainbow Holy Combo, the Hammer combo has priority due to dealing more average damage per GCD.  Note that this will not use Striking Muse automatically, it will only use the Hammer Combo if Striking Muse has already been activated.", PCT.JobID)]
     PictomancerHolyHammerCombo = 4217,
+
+    [IconsCombo([PCT.FireRedST, PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.HolyWhite, UTL.Blank, UTL.Idea, UTL.Danger])]
+    [SectionCombo("Holy/Comet")]
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Holy Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Holy (or Comet) if the next cast would overcap the Paint Gauge.\nThis is not recommended, as Holy is a small DPS loss versus continuing to cast your normal combos, and should generally be saved for movement instead.", PCT.JobID)]
+    PictomancerAutoHolyCombo = 4204,
+
+    [IconsCombo([PCT.FireRedST, PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, UTL.Blank, UTL.Idea])]
+    [SectionCombo("Holy/Comet")]
+    [AccessibilityCustomCombo]
+    [CustomComboInfo("Comet Autocast", "Replace Fire in Red, Fire II in Red, Blizzard in Cyan, Blizzard II in Cyan, and their combo chains, with Comet whenever it is available.\n\nNOTE: This will ensure you do not lose usages of Comet by forgetting about it, but also prevents holding Comet for movement after using Subtractive Palette, which can be a small loss due to potentially having to use Holy to cover that movement instead.", PCT.JobID)]
+    PictomancerAutoCometFeature = 4222,
+
+    [IconsCombo([PCT.FireRedST, PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, PCT.Buffs.SubstractivePalette, UTL.Cross])]
+    [SectionCombo("Holy/Comet")]
+    [ParentCombo(PictomancerAutoCometFeature)]
+    [SecretCustomCombo]
+    [CustomComboInfo("Auto-Comet after Subtractive", "Automatically use Comet only after using the 3 Subtractive charges from Subtractive Palette.\n\nNOTE: This allows Comet to be used manually to cover movement during the Subtractive combo, while still avoiding forgetting about it.  Note that since Subractive Palette can be used again as soon as the Subtractive combo has been completed, you CAN overwrite and waste Comet if you immediately use Subtractive Palette again after finishing the prior combo and before using the Comet from that prior combo.", PCT.JobID)]
+    PictomancerCometAfterSubtractive = 4224,
+
+    [IconsCombo([PCT.FireRedST, PCT.BlizzardCyanST, UTL.ArrowLeft, PCT.CometBlack, UTL.Blank, PCT.StarryMuse, UTL.Checkmark])]
+    [SectionCombo("Holy/Comet")]
+    [ParentCombo(PictomancerAutoCometFeature)]
+    [SecretCustomCombo]
+    [CustomComboInfo("Auto-Comet only during Starry", "Automatically use Comet only while Inspiration from Starry Muse is active\n\nNOTE: This prevents forgetting about Comet during the important Starry Muse cast sequence, while otherwise leaving it entirely up to the player to use or waste Comet.", PCT.JobID)]
+    PictomancerCometStarryOnly = 4228,
 
     #endregion
     // ====================================================================================

--- a/XIVComboExpanded/Interface/Changelog.cs
+++ b/XIVComboExpanded/Interface/Changelog.cs
@@ -13,6 +13,14 @@ namespace XIVComboExpanded.Interface
             return new Dictionary<string, string[]>()
                 {
                     {
+                        "v2.0.4.0",
+                        [
+                            "PCT: Several new combo features, especially around Rainbow Drip and Comet in Black.",
+                            "PCT: Reversed the order of the Automatic Subtractive features.  The parent combo now uses it as soon as available, the child combo only when it would overcap or would be free.  Check your enabled PCT combos.",
+                            "PCT: Automatic Subtractive and Rainbow Autocast now properly work with the AoE spell chains.",
+                        ]
+                    },
+                    {
                         "v2.0.3.0",
                         [
                             "API 12 update!",


### PR DESCRIPTION
* Inverted child/parent order of Subtractive autocast feature, so the more complicated and optimized feature is the child feature.
* Added a pair of new child features to only replace Creature Motif and the combo spells  with Mog of the Ages/Retribution of the Madeen if the next Muse cast would overwrite it, rather than as soon as it is available, to support better pooling of burst.
* Star Prism Autocast now notes that it has priority over Auto-Comet, and over Subtractive Pallet by default (modified by below child combo).
  * A new child combo of the above that makes Star Prism wait until after Subtractive (including using and consuming the free Subtractive from Starry Muse).
* Renamed the Rainbow Drip Starter to Rainbow Drip Combo Starter, and added a note indicating that it could cause issues if someone pulls early.
  * Added a new Rainbow Drip Holy Starter (separate combo, not child of the above), that instead replaces Holy with Rainbow Drip when out of combat, to avoid blocking the standard combo button if someone pulls early.
* Added a new combo, Comet Autocast, which works similar to Holy Autocast, except that it only gets used when Comet is available, and it uses it as soon as possible instead of just to avoid overcap (to avoid overwriting with another Subtractive usage).
  * Added a new child combo of Comet Autocast that delays the automatic Comet usage until Subtractive is no longer active, allowing Comet to be used to cover movement during Subtractive, but still gets auto-used.
  * Added a new child combo that only uses Comet Autocast when Inspiration from Starry Muse is active.  Also obeys the above After-Subtractive option, if enabled.
  * Comet is now also checked _before_ the Subtractive combo feature, to avoid automatically overwriting Comet when Auto-Subtractive is enabled.
* The Rainbow Holy Combo and the Holy Hammer Combo are no longer subordinate to the Holy Comet combo, as the logic is distinct.
  * Update the description of the Holy Hammer Combo to note that it has priority over both Comet and Rainbow Drip, if also enabled, and that it will not activate Striking Muse, just use the hammer charges if Striking Muse has already been activated.
  * Update the description of the Rainbow Holy Combo to note that Holy/Comet will be used first if Holy Autocast is enabled and you have 5 paint charges, as Rainbow Drip also generates a paint charge, and the Holy Autocast says it avoids overcapping (also implemented this check in the relevant combo code section).
* Recategorized a number of combos, merging most of the Rainbow Drip and single-combo sections into a general "Miscellaneous" section.
* Compressed the Levels block for PCT to remove a lot of redundant (and unused) fields.
* Fixes bugs with a couple features that should work with the AoE spells but don't.

Fixes #500 