### PR TITLE
[BUGFIX] RDM Embolden to Manafication skipping Prefulgence

### DIFF
--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -429,7 +429,7 @@ internal class RedMageEmbolden : CustomCombo
         {
             if (level >= RDM.Levels.Manafication && !IsCooldownUsable(RDM.Embolden))
             {
-                if (IsCooldownUsable(RDM.Manafication))
+                if (IsCooldownUsable(RDM.Manafication) && InCombat())
                     return RDM.Manafication;
                 if (HasEffect(RDM.Buffs.ThornedFlourish))
                     return RDM.ViceOfThorns;

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -48,6 +48,7 @@ internal static class RDM
             VerfireReady = 1234,
             VerstoneReady = 1235,
             Acceleration = 1238,
+            Manafication = 1239,
             Dualcast = 1249,
             LostChainspell = 2560,
             ThornedFlourish = 3876,
@@ -426,8 +427,15 @@ internal class RedMageEmbolden : CustomCombo
     {
         if (actionID == RDM.Embolden)
         {
-            if (level >= RDM.Levels.Manafication && IsCooldownUsable(RDM.Manafication) && !IsCooldownUsable(RDM.Embolden))
-                return RDM.Manafication;
+            if (level >= RDM.Levels.Manafication && !IsCooldownUsable(RDM.Embolden))
+            {
+                if (IsCooldownUsable(RDM.Manafication))
+                    return RDM.Manafication;
+                if (HasEffect(RDM.Buffs.ThornedFlourish))
+                    return RDM.ViceOfThorns;
+                if (HasEffect(RDM.Buffs.PrefulgenceReady) || HasEffect(RDM.Buffs.Manafication))
+                    return RDM.Prefulgence;
+            }
         }
 
         return actionID;

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -433,7 +433,7 @@ internal class RedMageEmbolden : CustomCombo
                     return RDM.Manafication;
                 if (HasEffect(RDM.Buffs.ThornedFlourish))
                     return RDM.ViceOfThorns;
-                if (HasEffect(RDM.Buffs.PrefulgenceReady) || HasEffect(RDM.Buffs.Manafication))
+                if (HasEffect(RDM.Buffs.PrefulgenceReady) || (level >= RDM.Levels.Prefulgence && HasEffect(RDM.Buffs.Manafication)))
                     return RDM.Prefulgence;
             }
         }

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -433,7 +433,7 @@ internal class RedMageEmbolden : CustomCombo
                     return RDM.Manafication;
                 if (HasEffect(RDM.Buffs.ThornedFlourish))
                     return RDM.ViceOfThorns;
-                if (HasEffect(RDM.Buffs.PrefulgenceReady) || (level >= RDM.Levels.Prefulgence && HasEffect(RDM.Buffs.Manafication)))
+                if (HasEffect(RDM.Buffs.PrefulgenceReady) || (level >= RDM.Levels.Prefulgence && IsEnabled(CustomComboPreset.RedMageManaficationPrefulgenceOverride) && HasEffect(RDM.Buffs.Manafication)))
                     return RDM.Prefulgence;
             }
         }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1936,11 +1936,18 @@ public enum CustomComboPreset
     [CustomComboInfo("Contre Sixte / Fleche Feature", "Replace Contre Sixte and Fleche with whichever is available.", RDM.JobID)]
     RedMageContreFlecheFeature = 3508,
 
-    [IconsCombo([RDM.Embolden, UTL.ArrowLeft, RDM.Manafication, UTL.ArrowLeft, RDM.ViceOfThorns, UTL.ArrowLeft, RDM.Prefulgence, UTL.Blank, RDM.Embolden, UTL.Clock])]
+    [IconsCombo([RDM.Embolden, UTL.ArrowLeft, RDM.Manafication, UTL.ArrowLeft, RDM.ViceOfThorns, UTL.ArrowLeft, RDM.Embolden, UTL.ArrowLeft, RDM.Prefulgence, UTL.Blank, RDM.Embolden, UTL.Clock])]
     [SectionCombo("Abilities features")]
     [ExpandedCustomCombo]
-    [CustomComboInfo("Embolden to Manafication", "Replace Embolden with Manafication if the former is on cooldown and the latter is not, then becomes Vice of Thorns and Prefulgence when readied or soon to be readied.", RDM.JobID)]
+    [CustomComboInfo("Embolden to Manafication", "Replace Embolden with Manafication if the former is on cooldown and the latter is not, then Vice of Thorns and Prefulgence when readied.", RDM.JobID)]
     RedMageEmboldenFeature = 3510,
+
+    [IconsCombo([RDM.ViceOfThorns, UTL.ArrowLeft, RDM.Prefulgence])]
+    [SectionCombo("Abilities features")]
+    [ParentCombo(RedMageEmboldenFeature)]
+    [ExpandedCustomCombo]
+    [CustomComboInfo("Combo directly from Vice of Thorns to Prefulgence", "Combo directly from Vice of Thorns to Prefulgence while still consuming Manafication stacks. No functional difference, but prevents icon reverting back to Embolden when Prefulgence will be used next.", RDM.JobID)]
+    RedMageManaficationPrefulgenceOverride = 3524,
 
     [IconsCombo([RDM.Acceleration, UTL.ArrowLeft, RDM.GrandImpact])]
     [SectionCombo("Abilities features")]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1936,10 +1936,10 @@ public enum CustomComboPreset
     [CustomComboInfo("Contre Sixte / Fleche Feature", "Replace Contre Sixte and Fleche with whichever is available.", RDM.JobID)]
     RedMageContreFlecheFeature = 3508,
 
-    [IconsCombo([RDM.Embolden, UTL.ArrowLeft, RDM.Manafication, UTL.Blank, RDM.Embolden, UTL.Clock])]
+    [IconsCombo([RDM.Embolden, UTL.ArrowLeft, RDM.Manafication, UTL.ArrowLeft, RDM.ViceOfThorns, UTL.ArrowLeft, RDM.Prefulgence, UTL.Blank, RDM.Embolden, UTL.Clock])]
     [SectionCombo("Abilities features")]
     [ExpandedCustomCombo]
-    [CustomComboInfo("Embolden to Manafication", "Replace Embolden with Manafication if the former is on cooldown and the latter is not.", RDM.JobID)]
+    [CustomComboInfo("Embolden to Manafication", "Replace Embolden with Manafication if the former is on cooldown and the latter is not, then becomes Vice of Thorns and Prefulgence when readied or soon to be readied.", RDM.JobID)]
     RedMageEmboldenFeature = 3510,
 
     [IconsCombo([RDM.Acceleration, UTL.ArrowLeft, RDM.GrandImpact])]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1942,11 +1942,11 @@ public enum CustomComboPreset
     [CustomComboInfo("Embolden to Manafication", "Replace Embolden with Manafication if the former is on cooldown and the latter is not, then Vice of Thorns and Prefulgence when readied.", RDM.JobID)]
     RedMageEmboldenFeature = 3510,
 
-    [IconsCombo([RDM.ViceOfThorns, UTL.ArrowLeft, RDM.Prefulgence])]
+    [IconsCombo([RDM.Embolden, UTL.ArrowLeft, RDM.Prefulgence])]
     [SectionCombo("Abilities features")]
     [ParentCombo(RedMageEmboldenFeature)]
     [ExpandedCustomCombo]
-    [CustomComboInfo("Combo directly from Vice of Thorns to Prefulgence", "Combo directly from Vice of Thorns to Prefulgence while still consuming Manafication stacks. No functional difference, but prevents icon reverting back to Embolden when Prefulgence will be used next.", RDM.JobID)]
+    [CustomComboInfo("Combo directly from Vice of Thorns to Prefulgence", "Replace Embolden with Prefulgence even when it isn't yet usable, as long as Vice of Thorns has been used and Manafication is still active. No functional difference, but prevents icon reverting back to Embolden when Prefulgence will be used next.", RDM.JobID)]
     RedMageManaficationPrefulgenceOverride = 3524,
 
     [IconsCombo([RDM.Acceleration, UTL.ArrowLeft, RDM.GrandImpact])]


### PR DESCRIPTION
Fixes #494.

Ensures combo into Vice of Thorns and Prefulgence actions (in that order of priority) after Embolden and Manafication are used and the readying buff is applied. Also shows unreadied Prefulgence while stacks of Manafication have yet to be consumed to indicate that should be readied soon.

Manafication will now not replace Embolden while out of combat, as it cannot be cast outside of combat.