### PR TITLE
[BUGFIX] Last Dance Feature & Partner Feature disabled when Dance Step Combo not enabled.

### DIFF
--- a/XIVComboExpanded/Combos/DNC.cs
+++ b/XIVComboExpanded/Combos/DNC.cs
@@ -164,7 +164,7 @@ internal class DancerFanDance12 : CustomCombo
 
 internal class DancerStandardStepTechnicalStep : CustomCombo
 {
-    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DancerDanceStepCombo;
+    protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DncAny;
 
     protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
     {
@@ -172,7 +172,7 @@ internal class DancerStandardStepTechnicalStep : CustomCombo
         {
             var gauge = GetJobGauge<DNCGauge>();
 
-            if (level >= DNC.Levels.StandardStep && gauge.IsDancing)
+            if (IsEnabled(CustomComboPreset.DancerDanceStepCombo) && level >= DNC.Levels.StandardStep && gauge.IsDancing)
             {
                 if (gauge.CompletedSteps < 2 && HasEffect(DNC.Buffs.StandardStep))
                     return gauge.NextStep;


### PR DESCRIPTION
Fixes #513

Looks like the bugfix from #507 accidentally made classic Last Dance Feature (3813) and expanded Partner Feature (3815) dependent on accessibility Dance Step Combo (3802) being enabled. They should now all be usable both independently or in conjunction as Kaedys intended.