### PR TITLE
[BUGFIX] DNC Dance Step Combo enabled for Technical Step even when disabled

### DIFF
--- a/XIVComboExpanded/Combos/DNC.cs
+++ b/XIVComboExpanded/Combos/DNC.cs
@@ -212,7 +212,7 @@ internal class DancerStandardStepTechnicalStep : CustomCombo
         {
             var gauge = GetJobGauge<DNCGauge>();
 
-            if (level >= DNC.Levels.StandardStep && gauge.IsDancing)
+            if (IsEnabled(CustomComboPreset.DancerDanceStepCombo) && level >= DNC.Levels.StandardStep && gauge.IsDancing)
             {
                 if (gauge.CompletedSteps < 4 && HasEffect(DNC.Buffs.TechnicalStep))
                     return gauge.NextStep;


### PR DESCRIPTION
Fixes bug reported in [this comment](https://github.com/MKhayle/XIVComboExpanded/pull/507#issuecomment-3201641431) on #507 

Adds Dance Step Combo (3802) enabled check for Technical Step replacement with next steps.